### PR TITLE
Fix elapsed-time year drift in ElapsedTimeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Elapsed-time display no longer drifts by ~5 days per year past your 1-year anniversary (was showing e.g. `2y 0m 10d` instead of `2y 0m 0d`).
+
 ## [0.4.0]
 
 ### Added

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1,0 +1,15 @@
+# Learnings
+
+Cross-cutting principles surfaced by past fixes in this repo. Each entry is the *principle* a future contributor needs — the example is an anchor, not a recap. Add to this list only when a fix exposes something a careful reader of the code couldn't infer for themselves.
+
+## Subtract in the unit you counted in
+
+When decomposing a `Time.Duration` into a `(years, months, days, hours, minutes)` tuple, the unit used to **extract** a component must match the unit used to **subtract that component back out** of the duration. Translating between units (years → days → seconds) opens the door to silent drift.
+
+Anchor: `source/stats/ElapsedTimeBuilder.mc`
+
+## Monkey C `Number / Number` truncates silently
+
+`365 / 12 == 30` because both operands are `Number`. If a constant looks fractional, it isn't unless one operand is forced to `Float`/`Double`: write `365.0 / 12` when you mean a real ratio. Constant names that imply fractions (`DAYS_IN_MONTH`, `AVG_…`, anything that sounds like a mean) without the matching type are a smell — verify the type before using them in proportional math.
+
+Anchor: `source/stats/Stats.mc`

--- a/source/stats/ElapsedTimeBuilder.mc
+++ b/source/stats/ElapsedTimeBuilder.mc
@@ -79,10 +79,6 @@ module Stats {
 
     private function _calculateYears(duration as Time.Duration) as ElapsedTime {
       var years = Math.floor(duration.value() / Gregorian.SECONDS_PER_YEAR);
-      // Subtract the exact same number of seconds we counted, so the
-      // remainder feeds cleanly into _calculateMonths. Using
-      // (years * 12 * DAYS_IN_MONTH) days here would drift by ~5 days
-      // per year because DAYS_IN_MONTH truncates 365/12 to 30.
       var remaining = duration.subtract(new Time.Duration(years.toNumber() * Gregorian.SECONDS_PER_YEAR));
       _elapsedTime.put(:years, years.toNumber());
       return _calculateMonths(remaining);

--- a/source/stats/ElapsedTimeBuilder.mc
+++ b/source/stats/ElapsedTimeBuilder.mc
@@ -78,8 +78,12 @@ module Stats {
     }
 
     private function _calculateYears(duration as Time.Duration) as ElapsedTime {
-      var years = Math.floor(duration.value() / (Gregorian.SECONDS_PER_YEAR));
-      var remaining = duration.subtract(Gregorian.duration({ :days => years * 12 * DAYS_IN_MONTH }));
+      var years = Math.floor(duration.value() / Gregorian.SECONDS_PER_YEAR);
+      // Subtract the exact same number of seconds we counted, so the
+      // remainder feeds cleanly into _calculateMonths. Using
+      // (years * 12 * DAYS_IN_MONTH) days here would drift by ~5 days
+      // per year because DAYS_IN_MONTH truncates 365/12 to 30.
+      var remaining = duration.subtract(new Time.Duration(years.toNumber() * Gregorian.SECONDS_PER_YEAR));
       _elapsedTime.put(:years, years.toNumber());
       return _calculateMonths(remaining);
     }

--- a/source/stats/Stats.tests.mc
+++ b/source/stats/Stats.tests.mc
@@ -107,14 +107,62 @@ module ElapsedTimeTests {
   }
 
   (:test)
-  function twoYears(logger as Logger) {
+  function exactlyOneYear(logger as Logger) {
     var duration = Stats.elapsedTimeSince(
       TestConsts.today.subtract(
-        new Time.Duration(Math.floor(2 * Gregorian.SECONDS_PER_YEAR))
+        new Time.Duration(Gregorian.SECONDS_PER_YEAR)
       ),
       TestConsts.today
     );
-    return TestUtils.verifyDictEquals(logger, duration, { :years => 2, :months => 0, :days => 10, :hours => 12, :minutes => 0 });
+
+    return TestUtils.verifyDictEquals(logger, duration, { :years => 1, :months => 0, :days => 0, :hours => 0, :minutes => 0 });
+  }
+
+  (:test)
+  function twoYearsExactly(logger as Logger) {
+    var duration = Stats.elapsedTimeSince(
+      TestConsts.today.subtract(
+        new Time.Duration(2 * Gregorian.SECONDS_PER_YEAR)
+      ),
+      TestConsts.today
+    );
+
+    return TestUtils.verifyDictEquals(logger, duration, { :years => 2, :months => 0, :days => 0, :hours => 0, :minutes => 0 });
+  }
+
+  (:test)
+  function fiveYearsExactly(logger as Logger) {
+    var duration = Stats.elapsedTimeSince(
+      TestConsts.today.subtract(
+        new Time.Duration(5 * Gregorian.SECONDS_PER_YEAR)
+      ),
+      TestConsts.today
+    );
+
+    return TestUtils.verifyDictEquals(logger, duration, { :years => 5, :months => 0, :days => 0, :hours => 0, :minutes => 0 });
+  }
+
+  (:test)
+  function tenYearsExactly(logger as Logger) {
+    var duration = Stats.elapsedTimeSince(
+      TestConsts.today.subtract(
+        new Time.Duration(10 * Gregorian.SECONDS_PER_YEAR)
+      ),
+      TestConsts.today
+    );
+
+    return TestUtils.verifyDictEquals(logger, duration, { :years => 10, :months => 0, :days => 0, :hours => 0, :minutes => 0 });
+  }
+
+  (:test)
+  function twoYearsThreeMonths(logger as Logger) {
+    var offset = (2 * Gregorian.SECONDS_PER_YEAR) + (3 * 30 * Gregorian.SECONDS_PER_DAY);
+    var duration = Stats.elapsedTimeSince(
+      TestConsts.today.subtract(new Time.Duration(offset)),
+      TestConsts.today
+    );
+
+    return TestUtils.verifyDictEquals(logger, duration, { :years => 2, :months => 3, :days => 0, :hours => 0, :minutes => 0 });
   }
 }
 


### PR DESCRIPTION
## Summary

- `_calculateYears` was subtracting `(years * 12 * DAYS_IN_MONTH)` days from the duration but counting years in `Gregorian.SECONDS_PER_YEAR` (365 days). Because `DAYS_IN_MONTH = 365 / 12` integer-truncates to 30, the subtracted period was only 360 days per year, leaving ~5 days/year of phantom remainder that bled into the `months`/`days` output.
- Fix: subtract `(years * Gregorian.SECONDS_PER_YEAR)` seconds — same units we counted in.
- The existing `twoYears` test asserted the buggy `{ days: 10, hours: 12 }` output; replaced with a set of boundary tests that pin the correct expectation.

## Visible effect

Before this fix, a user past their 2-year anniversary saw `2y 0m 10d …` instead of `2y 0m 0d`. At 10 years, the drift would have been roughly `10y 1m 20d`.

