### PR TITLE
Add CLI build tooling: Makefile + setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin
+out
 *.prg
 *.prg*
 *.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Smoke Free Companion is a Garmin Connect IQ **widget** (see `manifest.xml`) written in Monkey C. It shows users how long they've been smoke-free, cigarettes not smoked, and money saved since their configured quit date.
 
 - `minApiLevel`: 3.4.0
-- Supported devices: fenix6 and fenix7 lineups only (downgraded from a broader set in v0.4.0 — see CHANGELOG)
+- Supported devices: fenix6 and fenix7 lineups only (downgraded from a broader set in v0.4.0 — see CHANGELOG.md)
 - Languages: English (`resources/`) and Hungarian (`resources-hun/`)
 
 ## Build / Run / Test
@@ -51,7 +51,7 @@ Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(
 - `ElapsedTimeBuilder` (`stats/ElapsedTimeBuilder.mc`) converts a `Time.Duration` into the `ElapsedTime` struct that views render.
 - `Milestones.mc` defines progress milestones.
 
-**Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG). Currency is an index into a fixed `currencySymbols` array of resource symbols (`:SignUSD`, `:SignEUR`, `:SignHUF`); add new currencies in both the array and the strings resources.
+**Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG.md). Currency is an index into a fixed `currencySymbols` array of resource symbols (`:SignUSD`, `:SignEUR`, `:SignHUF`); add new currencies in both the array and the strings resources.
 
 **Tests** live next to the code they cover as `*.tests.mc` files using Toybox `(:test)` modules. `source/utils/TestUtils.mc` and `source/stats/Stats.tests.mc` set up shared `today` / `quitDate` moments inside a `TestConsts` module.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Smoke Free Companion is a Garmin Connect IQ **widget** (see `manifest.xml`) written in Monkey C. It shows users how long they've been smoke-free, cigarettes not smoked, and money saved since their configured quit date.
+
+- `minApiLevel`: 3.4.0
+- Supported devices: fenix6 and fenix7 lineups only (downgraded from a broader set in v0.4.0 — see CHANGELOG)
+- Languages: English (`resources/`) and Hungarian (`resources-hun/`)
+
+## Build / Run / Test
+
+Primary workflow is the **Makefile** (see `docs/setup.md` for one-time install):
+
+```bash
+make build              # compile for fenix6
+make test               # build with --unit-test + run in simulator
+make test DEVICE=fenix7 # other devices (package must be installed)
+make clean
+```
+
+`make test` succeeds (exit 0) when monkeydo prints `PASSED (passed=N, failed=0, errors=0)`. The simulator must be running; the target tries to start it but sometimes needs `open -a ConnectIQ` first on a cold boot.
+
+VS Code is still available — `.vscode/launch.json` defines **Run App** and **Run Tests** configurations against the device chosen via `GetTargetDevice` — but the CLI is the source of truth.
+
+Single-test runs are not supported by either path; `monkeydo -t` runs every `(:test)`-annotated function. Narrow scope by temporarily renaming functions.
+
+`monkey.jungle` simply points at `manifest.xml`; product/permission/language edits are done through the **Monkey C: Edit Application / Edit Products / Edit Permissions / Edit Languages** VS Code commands rather than by hand-editing `manifest.xml` (which is marked generated).
+
+## Architecture
+
+Entry point `source/App.mc` (`class App extends Application.AppBase`):
+
+- `getInitialView()` returns `CigarettesNotSmokedView` paired with a `NavigationBehavior(0)` delegate.
+- `getGlanceView()` returns `GlanceView` — the compact widget preview. Code reachable from the glance must be annotated `(:glance)` (see `App`, `Settings.getQuitDate`, `Stats.durationSince`, `Stats.elapsedTimeSince`).
+
+**View paging.** `source/view/NavigationBehavior.mc` is a `BehaviorDelegate` that cycles through 3 stat views via `onNextPage` / `onPreviousPage`, hard-coded in `getView(page)`:
+
+0. `CigarettesNotSmokedView`
+1. `MoneyNotSpentView`
+2. `CleanSinceView`
+
+Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(nextPage)` — page state is held in the delegate, not globally. When adding a new stat view, update both `_numberOfViews` and the `switch` in `getView`.
+
+**Stats module** (`source/stats/Stats.mc`) is pure functions over `Time.Moment`:
+
+- `durationSince`, `elapsedTimeSince` — used by glance and views.
+- `cigarettesNotSmoked` works in **hours**, not days (`cigarettesPerDay / 24` × duration-in-hours). This was a deliberate change in v0.4.0 for finer-grained updates; preserve hour-level math when modifying.
+- `ElapsedTimeBuilder` (`stats/ElapsedTimeBuilder.mc`) converts a `Time.Duration` into the `ElapsedTime` struct that views render.
+- `Milestones.mc` defines progress milestones.
+
+**Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG). Currency is an index into a fixed `currencySymbols` array of resource symbols (`:SignUSD`, `:SignEUR`, `:SignHUF`); add new currencies in both the array and the strings resources.
+
+**Tests** live next to the code they cover as `*.tests.mc` files using Toybox `(:test)` modules. `source/utils/TestUtils.mc` and `source/stats/Stats.tests.mc` set up shared `today` / `quitDate` moments inside a `TestConsts` module.
+
+## Conventions
+
+- Per `.editorconfig`: `.mc` and `.xml` files are 2-space indent, UTF-8, LF.
+- Any function/module that can be reached from the glance view must carry `(:glance)`, otherwise it will be stripped from the glance build and fail at runtime.
+- Hungarian translations live in a **separate** resource root (`resources-hun/`), not as `resources/strings/strings-hun.xml`. Mirror string IDs across both.

--- a/Makefile
+++ b/Makefile
@@ -8,39 +8,38 @@ OUT_DIR      ?= out
 JUNGLE       ?= monkey.jungle
 
 # monkeyc requires a JDK on PATH. Homebrew's openjdk is keg-only, so prepend
-# it here rather than rely on the user's shell config.
-JDK_BIN       := /opt/homebrew/opt/openjdk/bin
-SHELL         := /bin/zsh
-export PATH   := $(JDK_BIN):$(PATH)
+# it here rather than rely on the user's shell config. brew --prefix resolves
+# correctly on both Apple Silicon (/opt/homebrew) and Intel (/usr/local).
+JDK_BIN      := $(shell brew --prefix openjdk 2>/dev/null)/bin
+SHELL        := /bin/zsh
+export PATH  := $(JDK_BIN):$(PATH)
 
 APP_PRG      := $(OUT_DIR)/SmokeFreeCompanion.prg
 TEST_PRG     := $(OUT_DIR)/SmokeFreeCompanion-tests.prg
 
+# monkeyc builds in ~2s, so always rebuild rather than track a wildcard of
+# every .mc/resource file. Stale .prgs would be a much worse failure mode
+# than the extra two seconds.
 .PHONY: all build run test clean check-deps simulator
 
 all: build
 
 # Compile the widget for $(DEVICE).
-build: check-deps $(APP_PRG)
+build: check-deps | $(OUT_DIR)
+	monkeyc -f $(JUNGLE) -d $(DEVICE) -y "$(DEVELOPER_KEY)" -o $(APP_PRG) -w
 
 # Launch the widget in the simulator for manual testing.
-run: check-deps $(APP_PRG) simulator
+run: build simulator
 	monkeydo $(APP_PRG) $(DEVICE)
 
-$(APP_PRG): | $(OUT_DIR)
-	monkeyc -f $(JUNGLE) -d $(DEVICE) -y $(DEVELOPER_KEY) -o $@ -w
-
 # Compile with unit tests enabled, then run them in the simulator.
-# The simulator must already be running for monkeydo to attach.
 # monkeydo exits non-zero on a clean PASSED run, so we grep the
 # output for the summary line and exit on that instead.
-test: check-deps $(TEST_PRG) simulator
+test: check-deps simulator | $(OUT_DIR)
+	monkeyc -f $(JUNGLE) -d $(DEVICE) -y "$(DEVELOPER_KEY)" -o $(TEST_PRG) -t -w
 	@set -o pipefail; \
 	monkeydo $(TEST_PRG) $(DEVICE) -t 2>&1 | tee $(OUT_DIR)/test.log; \
 	grep -qE '^PASSED' $(OUT_DIR)/test.log
-
-$(TEST_PRG): | $(OUT_DIR)
-	monkeyc -f $(JUNGLE) -d $(DEVICE) -y $(DEVELOPER_KEY) -o $@ -t -w
 
 $(OUT_DIR):
 	mkdir -p $(OUT_DIR)
@@ -65,7 +64,7 @@ clean:
 check-deps:
 	@command -v monkeyc > /dev/null || { echo "monkeyc not found — run: brew install --cask connectiq"; exit 1; }
 	@command -v monkeydo > /dev/null || { echo "monkeydo not found — run: brew install --cask connectiq"; exit 1; }
-	@test -x $(JDK_BIN)/java || { echo "JDK not found at $(JDK_BIN) — run: brew install openjdk"; exit 1; }
-	@test -f $(DEVELOPER_KEY) || { echo "Developer key not found at $(DEVELOPER_KEY) — see docs/setup.md"; exit 1; }
+	@test -x "$(JDK_BIN)/java" || { echo "JDK not found at $(JDK_BIN) — run: brew install openjdk"; exit 1; }
+	@test -f "$(DEVELOPER_KEY)" || { echo "Developer key not found at $(DEVELOPER_KEY) — see docs/setup.md"; exit 1; }
 	@test -d "$(HOME)/Library/Application Support/Garmin/ConnectIQ/Devices/$(DEVICE)" \
 		|| { echo "Device package $(DEVICE) not installed — open /Applications/SdkManager.app"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,16 @@ export PATH   := $(JDK_BIN):$(PATH)
 APP_PRG      := $(OUT_DIR)/SmokeFreeCompanion.prg
 TEST_PRG     := $(OUT_DIR)/SmokeFreeCompanion-tests.prg
 
-.PHONY: all build test clean check-deps simulator
+.PHONY: all build run test clean check-deps simulator
 
 all: build
 
 # Compile the widget for $(DEVICE).
 build: check-deps $(APP_PRG)
+
+# Launch the widget in the simulator for manual testing.
+run: check-deps $(APP_PRG) simulator
+	monkeydo $(APP_PRG) $(DEVICE)
 
 $(APP_PRG): | $(OUT_DIR)
 	monkeyc -f $(JUNGLE) -d $(DEVICE) -y $(DEVELOPER_KEY) -o $@ -w

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Smoke Free Companion — build/test runner for the Connect IQ CLI.
+# See docs/setup.md for one-time environment setup.
+
+# Override on the command line, e.g. `make test DEVICE=fenix7`
+DEVICE       ?= fenix6
+DEVELOPER_KEY ?= $(HOME)/.garmin/developer_key.der
+OUT_DIR      ?= out
+JUNGLE       ?= monkey.jungle
+
+# monkeyc requires a JDK on PATH. Homebrew's openjdk is keg-only, so prepend
+# it here rather than rely on the user's shell config.
+JDK_BIN       := /opt/homebrew/opt/openjdk/bin
+SHELL         := /bin/zsh
+export PATH   := $(JDK_BIN):$(PATH)
+
+APP_PRG      := $(OUT_DIR)/SmokeFreeCompanion.prg
+TEST_PRG     := $(OUT_DIR)/SmokeFreeCompanion-tests.prg
+
+.PHONY: all build test clean check-deps simulator
+
+all: build
+
+# Compile the widget for $(DEVICE).
+build: check-deps $(APP_PRG)
+
+$(APP_PRG): | $(OUT_DIR)
+	monkeyc -f $(JUNGLE) -d $(DEVICE) -y $(DEVELOPER_KEY) -o $@ -w
+
+# Compile with unit tests enabled, then run them in the simulator.
+# The simulator must already be running for monkeydo to attach.
+# monkeydo exits non-zero on a clean PASSED run, so we grep the
+# output for the summary line and exit on that instead.
+test: check-deps $(TEST_PRG) simulator
+	@set -o pipefail; \
+	monkeydo $(TEST_PRG) $(DEVICE) -t 2>&1 | tee $(OUT_DIR)/test.log; \
+	grep -qE '^PASSED' $(OUT_DIR)/test.log
+
+$(TEST_PRG): | $(OUT_DIR)
+	monkeyc -f $(JUNGLE) -d $(DEVICE) -y $(DEVELOPER_KEY) -o $@ -t -w
+
+$(OUT_DIR):
+	mkdir -p $(OUT_DIR)
+
+# Start the simulator if it isn't already up. Idempotent.
+simulator:
+	@pgrep -f ConnectIQ.app > /dev/null || (open -a ConnectIQ && sleep 2)
+
+clean:
+	rm -rf $(OUT_DIR)
+
+# Fail fast if the toolchain isn't ready.
+check-deps:
+	@command -v monkeyc > /dev/null || { echo "monkeyc not found — run: brew install --cask connectiq"; exit 1; }
+	@command -v monkeydo > /dev/null || { echo "monkeydo not found — run: brew install --cask connectiq"; exit 1; }
+	@test -x $(JDK_BIN)/java || { echo "JDK not found at $(JDK_BIN) — run: brew install openjdk"; exit 1; }
+	@test -f $(DEVELOPER_KEY) || { echo "Developer key not found at $(DEVELOPER_KEY) — see docs/setup.md"; exit 1; }
+	@test -d "$(HOME)/Library/Application Support/Garmin/ConnectIQ/Devices/$(DEVICE)" \
+		|| { echo "Device package $(DEVICE) not installed — open /Applications/SdkManager.app"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,18 @@ $(TEST_PRG): | $(OUT_DIR)
 $(OUT_DIR):
 	mkdir -p $(OUT_DIR)
 
-# Start the simulator if it isn't already up. Idempotent.
+# Start the simulator if it isn't already up, then wait until it's
+# accepting connections on its control port. Idempotent.
+# monkeydo silently fails with "Unable to connect" if it tries to
+# attach before the simulator has finished booting (~5s on cold start).
+SIMULATOR_PORT := 1234
 simulator:
-	@pgrep -f ConnectIQ.app > /dev/null || (open -a ConnectIQ && sleep 2)
+	@pgrep -f ConnectIQ.app > /dev/null || open -a ConnectIQ
+	@for i in $$(seq 1 30); do \
+		nc -z localhost $(SIMULATOR_PORT) 2>/dev/null && exit 0; \
+		sleep 1; \
+	done; \
+	echo "Simulator did not become ready on port $(SIMULATOR_PORT)"; exit 1
 
 clean:
 	rm -rf $(OUT_DIR)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,116 @@
+# Dev environment setup
+
+One-time setup for building and testing this widget from the CLI on macOS.
+After this, `make build` and `make test` are the daily commands.
+
+> This guide assumes Apple Silicon. The paths under `/opt/homebrew` will be `/usr/local` on Intel Macs.
+
+## Prerequisites
+
+- macOS 11+
+- [Homebrew](https://brew.sh)
+- A free Garmin developer account (https://developer.garmin.com — needed by the SDK Manager to download device packages)
+
+## 1. Install the Connect IQ SDK and the SDK Manager
+
+```bash
+brew install --cask connectiq            # SDK runtime: monkeyc, monkeydo, simulator
+brew install --cask connectiq-sdk-manager # GUI for downloading device packages
+```
+
+The `connectiq` cask drops the binaries into `/opt/homebrew/bin`:
+
+```
+$ which monkeyc monkeydo
+/opt/homebrew/bin/monkeyc
+/opt/homebrew/bin/monkeydo
+```
+
+## 2. Install a JDK
+
+`monkeyc` is a Java program and needs a JDK on `PATH`. The Homebrew `openjdk` formula avoids the `sudo`-required `temurin` cask:
+
+```bash
+brew install openjdk
+```
+
+Homebrew's `openjdk` is keg-only, so it does **not** end up on `PATH` automatically. The `Makefile` prepends it for build/test invocations, so you don't need to edit your shell config — but if you ever invoke `monkeyc` directly, run:
+
+```bash
+export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
+```
+
+## 3. Generate a developer signing key
+
+Every Connect IQ build is signed with a private key. Generate yours once and reuse it forever — **back it up to a password manager**, you'll need the same key to publish updates to the Connect IQ Store.
+
+```bash
+mkdir -p ~/.garmin
+openssl genrsa -out ~/.garmin/developer_key.pem 4096
+openssl pkcs8 -topk8 -inform PEM -outform DER \
+  -in ~/.garmin/developer_key.pem \
+  -out ~/.garmin/developer_key.der -nocrypt
+chmod 600 ~/.garmin/developer_key.pem ~/.garmin/developer_key.der
+```
+
+`monkeyc` reads the DER form; the PEM is kept around in case you ever need to regenerate the DER or import the key into another tool.
+
+To put the key somewhere else, override `DEVELOPER_KEY` when running `make`:
+
+```bash
+make test DEVELOPER_KEY=/path/to/your/key.der
+```
+
+## 4. Install device packages via the SDK Manager
+
+```bash
+open -a SdkManager
+```
+
+In the SDK Manager:
+
+1. Sign in with your Garmin developer account.
+2. **Devices** tab → install **fenix6** (the canonical test target — API 3.4, which matches `manifest.xml`'s `minApiLevel`).
+3. Optional but recommended: install **fenix7** too, since the manifest targets both lineups.
+
+Device packages land in `~/Library/Application Support/Garmin/ConnectIQ/Devices/<deviceId>/`. The `Makefile`'s `check-deps` target reports a clear error if the package for the requested `DEVICE` isn't there.
+
+You do **not** need to install a separate "SDK" inside the SDK Manager — the binaries from the `connectiq` cask are self-contained. The Manager is only used here for device packages.
+
+## 5. Verify
+
+```bash
+make check-deps   # passes silently when everything is in place
+make build        # compiles for fenix6 by default
+make test         # runs the (:test) suite in the simulator
+```
+
+A clean `make test` ends with a line like `PASSED (passed=25, failed=0, errors=0)` and exits 0.
+
+If `make test` reports `Unable to connect to simulator`, the simulator isn't running yet — the `Makefile` tries to start it but sometimes needs more time on the first invocation. Re-run, or `open -a ConnectIQ` first.
+
+## Targeting a different device
+
+```bash
+make test DEVICE=fenix7
+```
+
+The device package for the target must be installed in the SDK Manager first.
+
+## Recovering from a stuck simulator
+
+`monkeydo` connects to the running simulator process. If a prior test run left it in a weird state (window hangs, `monkeydo` doesn't return), reset:
+
+```bash
+pkill -f ConnectIQ.app
+pkill -f MonkeyDoDeux
+open -a ConnectIQ
+```
+
+Then retry `make test`.
+
+## Notes & quirks
+
+- `monkeydo` returns a non-zero exit code even on a successful `PASSED` run. The Makefile's `test` target compensates by grepping `out/test.log` for the summary line.
+- The build emits `Invalid device id` warnings for every product in `manifest.xml` whose device package isn't installed locally. These are harmless — the build succeeds for the device you asked for. Install the missing packages via the SDK Manager to silence them.
+- Two pre-existing type-checker warnings (`Cannot determine if container access is using container type`) show up on every build. They're tracked in `docs/_zee/findings.md` §6 and §17.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,11 +34,17 @@ $ which monkeyc monkeydo
 brew install openjdk
 ```
 
-Homebrew's `openjdk` is keg-only, so it does **not** end up on `PATH` automatically. The `Makefile` prepends it for build/test invocations, so you don't need to edit your shell config — but if you ever invoke `monkeyc` directly, run:
+Homebrew's `openjdk` is keg-only, so it does **not** end up on `PATH` automatically. The `Makefile` prepends it for its own recipes, but a plain shell won't see it — `monkeydo out/foo.prg fenix6` will fail with *"Unable to locate a Java Runtime"* until you fix `PATH`.
+
+Append to `~/.zshrc` so every shell picks it up (one-time, recommended):
 
 ```bash
-export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
+echo '' >> ~/.zshrc
+echo '# Homebrew openjdk is keg-only; needed by monkeyc/monkeydo (Garmin Connect IQ)' >> ~/.zshrc
+echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
 ```
+
+Then `source ~/.zshrc` (or open a new terminal). Verify with `java --version` — should print `openjdk 25.x`.
 
 ## 3. Generate a developer signing key
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -122,4 +122,4 @@ Then retry `make test`.
 
 - `monkeydo` returns a non-zero exit code even on a successful `PASSED` run. The Makefile's `test` target compensates by grepping `out/test.log` for the summary line.
 - The build emits `Invalid device id` warnings for every product in `manifest.xml` whose device package isn't installed locally. These are harmless — the build succeeds for the device you asked for. Install the missing packages via the SDK Manager to silence them.
-- Two pre-existing type-checker warnings (`Cannot determine if container access is using container type`) show up on every build. They're tracked in `docs/_zee/findings.md` §6 and §17.
+- Two pre-existing type-checker warnings (`Cannot determine if container access is using container type`) show up on every build in `Settings.mc` and `GlanceView.mc`. Known, not a regression.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -82,10 +82,13 @@ You do **not** need to install a separate "SDK" inside the SDK Manager — the b
 ```bash
 make check-deps   # passes silently when everything is in place
 make build        # compiles for fenix6 by default
+make run          # launch the widget in the simulator for manual testing
 make test         # runs the (:test) suite in the simulator
 ```
 
 A clean `make test` ends with a line like `PASSED (passed=25, failed=0, errors=0)` and exits 0.
+
+`make run` leaves the simulator window open until you close it. Use the simulator's **Settings → Edit Persistent Storage** to change pack price / quit date / etc. without rebuilding, and the **Device** menu to switch form factor mid-session.
 
 If `make test` reports `Unable to connect to simulator`, the simulator isn't running yet — the `Makefile` tries to start it but sometimes needs more time on the first invocation. Re-run, or `open -a ConnectIQ` first.
 


### PR DESCRIPTION
## Summary

- New `Makefile` wraps `monkeyc` / `monkeydo` so `make build` and `make test` are the daily commands. `check-deps` target gives a clear error when JDK, SDK binaries, developer key, or device package is missing.
- `docs/setup.md` walks through Homebrew install of the SDK + openjdk, generating a 4096-bit RSA developer key with `openssl`, and downloading device packages via the SDK Manager GUI. Replicable on a fresh macOS machine.
- `CLAUDE.md` added so future Claude Code instances pick up the CLI workflow as the source of truth.
- `out/` added to `.gitignore` (build artifacts).

## Why

VS Code's Monkey C launch configs work, but they don't compose into automation: no CI, no scripted multi-device matrix, no way for an AI assistant to verify its own fix. The Makefile gives us all of those for the cost of a 30-line file.

## Test plan

Tested locally on macOS 15 / Apple Silicon:

```
$ make check-deps    # exit 0
$ make build         # exit 0, produces out/SmokeFreeCompanion.prg
$ make test          # exit 0, "PASSED (passed=25, failed=0, errors=0)"
```

Setup steps in `docs/setup.md` followed end-to-end on this machine. Anyone following the doc should hit the same state.

Not affected: VS Code "Run App" / "Run Tests" launch configs still work; this PR doesn't remove them.

## Note for reviewers

Quirks captured in `docs/setup.md` worth knowing:

- `openjdk` is keg-only; the Makefile prepends its bin to `PATH` so you don't have to edit your shell config.
- `monkeydo` exits non-zero even on a clean `PASSED` run, so the `test` target greps the output instead of trusting the exit code.
- The build emits one `Invalid device id` warning per device in `manifest.xml` whose package isn't installed locally. Harmless — the requested device still builds.