### PR TITLE
refactor: rename DAYS_IN_MONTH to APPROX_DAYS_PER_MONTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Internal: renamed `DAYS_IN_MONTH` to `APPROX_DAYS_PER_MONTH` so callers can't mistake the truncated value (30) for a precise one. No user-visible change.
+
 ## [0.4.0]
 
 ### Added

--- a/source/stats/ElapsedTimeBuilder.mc
+++ b/source/stats/ElapsedTimeBuilder.mc
@@ -72,14 +72,14 @@ module Stats {
 
     private function _calculateMonths(duration as Time.Duration) as ElapsedTime {
       var months = Math.floor(duration.value() / dMonth);
-      var remaining = duration.subtract(Gregorian.duration({ :days => months * DAYS_IN_MONTH }));
+      var remaining = duration.subtract(Gregorian.duration({ :days => months * APPROX_DAYS_PER_MONTH }));
       _elapsedTime.put(:months, months.toNumber());
       return _calculateDays(remaining);
     }
 
     private function _calculateYears(duration as Time.Duration) as ElapsedTime {
       var years = Math.floor(duration.value() / (Gregorian.SECONDS_PER_YEAR));
-      var remaining = duration.subtract(Gregorian.duration({ :days => years * 12 * DAYS_IN_MONTH }));
+      var remaining = duration.subtract(Gregorian.duration({ :days => years * 12 * APPROX_DAYS_PER_MONTH }));
       _elapsedTime.put(:years, years.toNumber());
       return _calculateMonths(remaining);
     }

--- a/source/stats/Stats.mc
+++ b/source/stats/Stats.mc
@@ -5,11 +5,13 @@ import Toybox.Time.Gregorian;
 import Toybox.Math;
 
 module Stats {
-  const DAYS_IN_MONTH = 365 / 12;
+  // Approximation used when decomposing a Duration into y/m/d. Months
+  // in Gregorian are variable-length; 30 = floor(365 / 12).
+  const APPROX_DAYS_PER_MONTH = 30;
 
   var dHour = Gregorian.SECONDS_PER_HOUR;
   var dDay = Gregorian.SECONDS_PER_DAY;
-  var dMonth = DAYS_IN_MONTH * Gregorian.SECONDS_PER_DAY;
+  var dMonth = APPROX_DAYS_PER_MONTH * Gregorian.SECONDS_PER_DAY;
 
   /**
    * Calculates the duration between the quit date and today.


### PR DESCRIPTION
## Summary

- `DAYS_IN_MONTH = 365 / 12` reads like a fractional ~30.42 but is `30` because Monkey C does integer division on `Number / Number`. The value works fine in its callers (month threshold + days-per-month subtraction in the duration decomposer) but the name promises precision it doesn't have.
- Renamed to `APPROX_DAYS_PER_MONTH`. Value is now written as a bare `30` with a one-line comment naming the derivation (`floor(365 / 12)`). The approximation is now explicit at the definition site and at every call site.
- Pure non-functional refactor. No tests added or changed.

## Visible effect

None — internal rename only.

## Test plan

```
$ make test
…
Ran 21 tests

PASSED (passed=21, failed=0, errors=0)
```

All existing tests pass identically against the renamed constant.

## Changelog

Added under `[Unreleased]` → `Changed`:

> Internal: renamed `DAYS_IN_MONTH` to `APPROX_DAYS_PER_MONTH` so callers can't mistake the truncated value (30) for a precise one. No user-visible change.

## Note on overlap with #6

PR #6 (`fix/elapsed-time-year-drift`) deletes the `_calculateYears` line that uses this constant. If #6 merges first, this PR rebases with a trivial one-line conflict — keep #6's version. If this PR merges first, #6 rebases trivially.