### PR TITLE
fix: cigarettesNotSmoked integer-truncates fractional hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Elapsed-time display no longer drifts by ~5 days per year past your 1-year anniversary (was showing e.g. `2y 0m 10d` instead of `2y 0m 0d`).
+- Cigarettes-not-smoked count now updates continuously within each hour, instead of staying at zero until a full hour elapses.
 
 ## [0.4.0]
 

--- a/source/stats/Stats.mc
+++ b/source/stats/Stats.mc
@@ -46,7 +46,7 @@ module Stats {
    * @return The estimated number of cigarettes not smoked.
    */
   function cigarettesNotSmoked(quitDate as Time.Moment, today as Time.Moment, cigarettesPerDay as Number) as Number {
-    var durationInHours = durationSince(quitDate, today).value() / dHour;
+    var durationInHours = durationSince(quitDate, today).value().toDouble() / dHour;
     var cigarettesPerHour = cigarettesPerDay.toDouble() / 24;
     return Math.floor(durationInHours * cigarettesPerHour).toNumber();
   }

--- a/source/stats/Stats.tests.mc
+++ b/source/stats/Stats.tests.mc
@@ -178,6 +178,20 @@ module CigarettesNotSmokedTests {
   }
 
   (:test)
+  function cigsInHalfHour(logger as Logger) {
+    var halfHour = new Time.Duration(Gregorian.SECONDS_PER_HOUR / 2);
+    var res = Stats.cigarettesNotSmoked(TestConsts.today.subtract(halfHour), TestConsts.today, 48);
+    return TestUtils.verifyValueEquals(logger, res, 1);
+  }
+
+  (:test)
+  function cigsInOneAndHalfHours(logger as Logger) {
+    var ninetyMin = new Time.Duration(Gregorian.SECONDS_PER_HOUR + Gregorian.SECONDS_PER_HOUR / 2);
+    var res = Stats.cigarettesNotSmoked(TestConsts.today.subtract(ninetyMin), TestConsts.today, 48);
+    return TestUtils.verifyValueEquals(logger, res, 3);
+  }
+
+  (:test)
   function cigarettesNotSmoked(logger as Logger) {
     var res = Stats.cigarettesNotSmoked(TestConsts.quitDate, TestConsts.today, 10);
     return TestUtils.verifyValueEquals(logger, res, 10);


### PR DESCRIPTION
## Summary

- `durationSince().value()` returns a `Number` (seconds); dividing by `SECONDS_PER_HOUR` (also a `Number`) truncated any sub-hour remainder before the multiplication, so partial hours counted as zero cigarettes.
- Fix: call `.toDouble()` on the duration value before dividing, so the fractional hours are preserved through `Math.floor`.
- Change is one character on one line; no callers compensated for the buggy behaviour.

## Visible effect

Before: a user who smokes 48 cigarettes/day and has been smoke-free for 30 minutes saw **0** cigarettes not smoked (30 min = 0 full hours → 0 × 2/hr = 0).

After: the same user sees **1** cigarette not smoked (30 min = 0.5 hours → floor(0.5 × 2) = 1).

## Test plan

Two new cases added to `CigarettesNotSmokedTests`, both using 48 cigs/day to make sub-hour fractions visible:

```
CigarettesNotSmokedTests.cigsInHalfHour             PASS
CigarettesNotSmokedTests.cigsInOneAndHalfHours      PASS
...
Ran 27 tests
PASSED (passed=27, failed=0, errors=0)
```

## Changelog

> Cigarettes-not-smoked count now updates continuously within each hour, instead of staying at zero until a full hour elapses.