### PR TITLE
fix: clamp milestoneProgress to 1.0 past the last milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Elapsed-time display no longer drifts by ~5 days per year past your 1-year anniversary (was showing e.g. `2y 0m 10d` instead of `2y 0m 0d`).
 - Cigarettes-not-smoked count now updates continuously within each hour, instead of staying at zero until a full hour elapses.
+- Milestone progress bar no longer overflows past the screen edge for users beyond the last milestone (50 years).
 
 ## [0.4.0]
 

--- a/source/stats/Milestones.mc
+++ b/source/stats/Milestones.mc
@@ -71,6 +71,11 @@ module Milestones {
   function milestoneProgress(moment as Time.Moment) as Lang.Float {
     var today = new Time.Moment(Time.now().value());
     var elapsedTime = Stats.durationSince(moment, today);
+
+    if (elapsedTime.value() >= MILESTONES[NUMBER_OF_MILESTONES - 1]) {
+      return 1.0;
+    }
+
     var milestone = closestMilestoneTo(moment);
     var remaining = milestone - elapsedTime.value();
 

--- a/source/stats/Milestones.tests.mc
+++ b/source/stats/Milestones.tests.mc
@@ -60,6 +60,14 @@ module MilestonesTests {
   }
 
   (:test)
+  function progressPastLastMilestone(logger as Logger) {
+    var fiftyOneYears = new Time.Duration(51 * Gregorian.SECONDS_PER_YEAR);
+    var quitTime = today.subtract(fiftyOneYears) as Time.Moment;
+    var progress = Milestones.milestoneProgress(quitTime);
+    return TestUtils.verifyValueEquals(logger, progress, 1.0);
+  }
+
+  (:test)
   function exactMilestoneHasToBeHundredPercent(logger as Logger) {
     for (var i = 0; i < Milestones.NUMBER_OF_MILESTONES; i++) {
       var milestone = Milestones.MILESTONES[i];


### PR DESCRIPTION
## Summary

- When elapsed time exceeds the last milestone (50 years), `closestMilestoneTo` returns that milestone and `milestoneProgress` computes a negative `remaining`, yielding progress > 1.0.
- Fix: early-out at the top of `milestoneProgress` — if elapsed ≥ last milestone, return `1.0` before touching `remaining`.
- `GlanceView` multiplies `width * progress` directly to draw the progress bar; without the clamp it would draw past the right edge of the screen.

## Visible effect

Before: a user with ≥ 50 smoke-free years would see a progress bar drawn past the screen edge in the glance view.

After: the progress bar stays pinned at 100% (full width) once the last milestone is reached.

## Test plan

```
MilestonesTests.progressPastLastMilestone           PASS
MilestonesTests.exactMilestoneHasToBeHundredPercent PASS
...
Ran 28 tests
PASSED (passed=28, failed=0, errors=0)
```

## Changelog

> Milestone progress bar no longer overflows past the screen edge for users beyond the last milestone (50 years).