### PR TITLE
feat: refresh views immediately on settings change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Settings edits (quit date, pack price, cigarettes per day, currency, etc.) now take effect immediately without needing to relaunch the widget.
+
 ## [0.4.1] - 2026-05-16
 
 ### Changed

--- a/source/App.mc
+++ b/source/App.mc
@@ -30,6 +30,10 @@ class App extends Application.AppBase {
     return [nav.getView(0), nav] as [WatchUi.Views, WatchUi.InputDelegates];
   }
 
+  function onSettingsChanged() as Void {
+    WatchUi.requestUpdate();
+  }
+
 }
 
 function getApp() as App {

--- a/source/view/CigarettesNotSmokedView.mc
+++ b/source/view/CigarettesNotSmokedView.mc
@@ -9,19 +9,21 @@ class CigarettesNotSmokedView extends StatView {
     StatView.initialize();
   }
 
-  // loading resources into memory.
   function onShow() as Void {
     StatView.onShow();
 
     iconResource = WatchUi.loadResource(Rez.Drawables.CigarettesNotSmokedIcon) as BitmapResource;
     subTitle = WatchUi.loadResource(Rez.Strings.Cigarettes) as Lang.String;
+  }
 
+  function onUpdate(dc as Dc) as Void {
     var cigs = Stats.cigarettesNotSmoked(
       Settings.getQuitDate(),
       new Time.Moment(Time.now().value()),
       Settings.getCigarettesPerDay()
     );
-
     title = cigs.format("%u");
+
+    StatView.onUpdate(dc);
   }
 }

--- a/source/view/CleanSinceView.mc
+++ b/source/view/CleanSinceView.mc
@@ -25,31 +25,29 @@ class CleanSinceView extends StatView {
     _dateFormat = Application.loadResource( Rez.Strings.DateFormat );
   }
 
-  // loading resources into memory.
   function onShow() as Void {
     StatView.onShow();
 
     iconResource = WatchUi.loadResource(Rez.Drawables.QuitDateIcon) as BitmapResource;
-    subTitle = _subTitle;
-    
+  }
+
+  function onUpdate(dc as Dc) as Void {
     var quitDate = Settings.getQuitDate();
     var now = new Time.Moment(Time.today().value());
-    
+
     if (now.subtract(quitDate).value() < Gregorian.SECONDS_PER_DAY) {
       title = _oneDayTitle;
       subTitle = _oneDaySubTitle;
     } else {
       var quitDateInfo = Gregorian.info(quitDate, Time.FORMAT_MEDIUM);
-      var dateString = Lang.format(
+      title = Lang.format(
         _dateFormat,
-        [
-          quitDateInfo.day,
-          quitDateInfo.month,
-          quitDateInfo.year
-        ]
+        [quitDateInfo.day, quitDateInfo.month, quitDateInfo.year]
       );
-      title = dateString;
+      subTitle = _subTitle;
     }
+
+    StatView.onUpdate(dc);
   }
   
   function drawTitle(dc as Dc) as Void {

--- a/source/view/MoneyNotSpentView.mc
+++ b/source/view/MoneyNotSpentView.mc
@@ -24,7 +24,9 @@ class MoneyNotSpentView extends StatView {
 
     iconResource = WatchUi.loadResource(Rez.Drawables.MoneyNotSpentIcon) as BitmapResource;
     subTitle = WatchUi.loadResource(Rez.Strings.Saved) as Lang.String;
+  }
 
+  function onUpdate(dc as Dc) as Void {
     _currencyConfig = Settings.getCurrencyConfig();
 
     var packs = Stats.packsNotBought(
@@ -36,6 +38,8 @@ class MoneyNotSpentView extends StatView {
 
     var price = packs * Settings.getPackPrice();
     title = price.format((_currencyConfig as Lang.Dictionary)[:priceFormat] as String);
+
+    StatView.onUpdate(dc);
   }
 
   // Override to add currency symbol to title


### PR DESCRIPTION
## Summary

- Override `App.onSettingsChanged` to call `WatchUi.requestUpdate()`.
- Move settings-dependent state out of `onShow()` and into `onUpdate()` for all three stat views. Resource loads (icons, static strings) stay in `onShow()`.

## Visible effect

**Before:** user changes their quit date / pack price / cigarettes-per-day in Garmin Connect Mobile → widget shows stale values until force-quit and reopen.

**After:** the widget redraws with fresh values on the next frame.

## Why move computation to `onUpdate`

`Application.AppBase.onSettingsChanged` is fired by the SDK when Connect Mobile pushes new settings, but it triggers `onUpdate`, not `onShow`. Pulling settings on every redraw is cheap (a few `Properties.getValue` calls + a `format`); a stat widget redraws a handful of times per minute.

## Test plan

- [x] `make test` → PASSED (passed=28, failed=0, errors=0).
- [x] `make build` clean.
- [ ] Manual: change `packPrice` in the simulator's settings dialog while the widget is in `MoneyNotSpentView`; verify the displayed amount updates without relaunch.

Closes the `onSettingsChanged` half of Phase 1 (improvements §3).