### PR TITLE
feat: remember last-viewed stat page across launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The widget now remembers the last-viewed stat page and reopens to it on next launch.
+
 ## [0.4.1] - 2026-05-16
 
 ### Changed

--- a/source/App.mc
+++ b/source/App.mc
@@ -26,8 +26,10 @@ class App extends Application.AppBase {
 
   // Return the initial view of your application here
   function getInitialView() as [WatchUi.Views] or [WatchUi.Views, WatchUi.InputDelegates] {
-    var nav = new NavigationBehavior(0);
-    return [nav.getView(0), nav] as [WatchUi.Views, WatchUi.InputDelegates];
+    var stored = Application.Storage.getValue("lastPage");
+    var page = stored instanceof Lang.Number ? stored : 0;
+    var nav = new NavigationBehavior(page);
+    return [nav.getView(page), nav] as [WatchUi.Views, WatchUi.InputDelegates];
   }
 
 }

--- a/source/view/NavigationBehavior.mc
+++ b/source/view/NavigationBehavior.mc
@@ -1,3 +1,4 @@
+import Toybox.Application;
 import Toybox.WatchUi;
 import Toybox.Lang;
 
@@ -7,6 +8,7 @@ class NavigationBehavior extends BehaviorDelegate {
 
   function initialize(currentPage as Number) {
     _currentPage = currentPage;
+    Storage.setValue("lastPage", currentPage);
     BehaviorDelegate.initialize();
   }
 


### PR DESCRIPTION
## Summary

- `NavigationBehavior.initialize` now writes the current page index to `Application.Storage` under `"lastPage"`.
- `App.getInitialView` reads it back (defaulting to `0` if missing or non-numeric) so the widget reopens on the page the user was last viewing.

## Visible effect

**Before:** every cold launch lands on `CigarettesNotSmokedView` (page 0), regardless of where the user was last.

**After:** the widget resumes on the last page the user viewed before backing out / glance dismissal.

## Safety

`NavigationBehavior.getView` already has a `default` case that falls back to page 0, so a stale or corrupted stored value cannot crash the app.

## Test plan

- [x] `make test` → PASSED (passed=28, failed=0, errors=0).
- [x] `make build` clean.
- [ ] Manual: navigate to page 2 (CleanSinceView), force-quit, relaunch — should open to page 2.

Phase 1 item — last-viewed-page persistence (improvements §1, second half).