### PR TITLE
Fix App Settings Editor in simulator + Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,30 @@ JUNGLE       ?= monkey.jungle
 # it here rather than rely on the user's shell config. brew --prefix resolves
 # correctly on both Apple Silicon (/opt/homebrew) and Intel (/usr/local).
 JDK_BIN      := $(shell brew --prefix openjdk 2>/dev/null)/bin
+# Honor whichever SDK the user has marked active via the SDK Manager. The
+# brew symlinks always point at the latest installed cask, which may not
+# match the chosen SDK. current-sdk.cfg already includes a trailing slash.
+SDK_DIR      := $(shell cat "$(HOME)/Library/Application Support/Garmin/ConnectIQ/current-sdk.cfg" 2>/dev/null)
+SDK_BIN      := $(SDK_DIR)bin
 SHELL        := /bin/zsh
-export PATH  := $(JDK_BIN):$(PATH)
+export PATH  := $(SDK_BIN):$(JDK_BIN):$(PATH)
 
-APP_PRG      := $(OUT_DIR)/SmokeFreeCompanion.prg
-APP_SETTINGS := $(OUT_DIR)/SmokeFreeCompanion-settings.json
+# Bundle name — drives the PRG filename, the sidecar JSON, and the
+# in-simulator settings destination. manifest.xml's name attribute is a
+# @Strings.* resource reference, not a literal, so it's set here directly.
+APP_NAME     := SmokeFreeCompanion
+APP_PRG      := $(OUT_DIR)/$(APP_NAME).prg
+APP_SETTINGS := $(OUT_DIR)/$(APP_NAME)-settings.json
 # The simulator's App Settings Editor reads the sidecar from a fixed path
 # inside the simulator's vfs: GARMIN/Settings/<APP>-settings.json. Without
 # this, the editor reports "No settings file found for this app."
-SETTINGS_DEST := GARMIN/Settings/SMOKEFREECOMPANION-settings.json
-TEST_PRG     := $(OUT_DIR)/SmokeFreeCompanion-tests.prg
+SETTINGS_DEST := GARMIN/Settings/$(shell echo $(APP_NAME) | tr '[:lower:]' '[:upper:]')-settings.json
+TEST_PRG     := $(OUT_DIR)/$(APP_NAME)-tests.prg
 
 # monkeyc builds in ~2s, so always rebuild rather than track a wildcard of
 # every .mc/resource file. Stale .prgs would be a much worse failure mode
 # than the extra two seconds.
-.PHONY: all build run test clean check-deps simulator
+.PHONY: all build run test clean check-deps simulator crashes
 
 all: build
 
@@ -46,6 +55,13 @@ test: check-deps simulator | $(OUT_DIR)
 	monkeydo $(TEST_PRG) $(DEVICE) -t 2>&1 | tee $(OUT_DIR)/test.log; \
 	grep -qE '^PASSED' $(OUT_DIR)/test.log
 
+# Fetch crash reports for the published app from Garmin's servers. Requires
+# APP_ID (the manifest <iq:application id>) to be set on the command line:
+#   make crashes APP_ID=8d26c065-6a61-4a68-bbd9-4b82e62462c5
+crashes:
+	@test -n "$(APP_ID)" || { echo "Usage: make crashes APP_ID=<app-uuid>"; exit 1; }
+	$(SDK_BIN)/era -a $(APP_ID) -k "$(DEVELOPER_KEY)"
+
 $(OUT_DIR):
 	mkdir -p $(OUT_DIR)
 
@@ -53,9 +69,11 @@ $(OUT_DIR):
 # accepting connections on its control port. Idempotent.
 # monkeydo silently fails with "Unable to connect" if it tries to
 # attach before the simulator has finished booting (~5s on cold start).
+# Launch via the active SDK's bundle so we don't get whichever copy
+# macOS has registered for `open -a ConnectIQ`.
 SIMULATOR_PORT := 1234
 simulator:
-	@pgrep -f ConnectIQ.app > /dev/null || open -a ConnectIQ
+	@pgrep -f ConnectIQ.app > /dev/null || open -a "$(SDK_BIN)/ConnectIQ.app"
 	@for i in $$(seq 1 30); do \
 		nc -z localhost $(SIMULATOR_PORT) 2>/dev/null && exit 0; \
 		sleep 1; \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: check-deps simulator | $(OUT_DIR)
 #   make crashes APP_ID=8d26c065-6a61-4a68-bbd9-4b82e62462c5
 crashes:
 	@test -n "$(APP_ID)" || { echo "Usage: make crashes APP_ID=<app-uuid>"; exit 1; }
-	$(SDK_BIN)/era -a $(APP_ID) -k "$(DEVELOPER_KEY)"
+	"$(SDK_BIN)/era" -a $(APP_ID) -k "$(DEVELOPER_KEY)"
 
 $(OUT_DIR):
 	mkdir -p $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ TEST_PRG     := $(OUT_DIR)/$(APP_NAME)-tests.prg
 # monkeyc builds in ~2s, so always rebuild rather than track a wildcard of
 # every .mc/resource file. Stale .prgs would be a much worse failure mode
 # than the extra two seconds.
-.PHONY: all build run test clean check-deps simulator crashes
+.PHONY: all build run test clean check-deps simulator
 
 all: build
 
@@ -54,13 +54,6 @@ test: check-deps simulator | $(OUT_DIR)
 	@set -o pipefail; \
 	monkeydo $(TEST_PRG) $(DEVICE) -t 2>&1 | tee $(OUT_DIR)/test.log; \
 	grep -qE '^PASSED' $(OUT_DIR)/test.log
-
-# Fetch crash reports for the published app from Garmin's servers. Requires
-# APP_ID (the manifest <iq:application id>) to be set on the command line:
-#   make crashes APP_ID=8d26c065-6a61-4a68-bbd9-4b82e62462c5
-crashes:
-	@test -n "$(APP_ID)" || { echo "Usage: make crashes APP_ID=<app-uuid>"; exit 1; }
-	"$(SDK_BIN)/era" -a $(APP_ID) -k "$(DEVELOPER_KEY)"
 
 $(OUT_DIR):
 	mkdir -p $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ SHELL        := /bin/zsh
 export PATH  := $(JDK_BIN):$(PATH)
 
 APP_PRG      := $(OUT_DIR)/SmokeFreeCompanion.prg
+APP_SETTINGS := $(OUT_DIR)/SmokeFreeCompanion-settings.json
+# The simulator's App Settings Editor reads the sidecar from a fixed path
+# inside the simulator's vfs: GARMIN/Settings/<APP>-settings.json. Without
+# this, the editor reports "No settings file found for this app."
+SETTINGS_DEST := GARMIN/Settings/SMOKEFREECOMPANION-settings.json
 TEST_PRG     := $(OUT_DIR)/SmokeFreeCompanion-tests.prg
 
 # monkeyc builds in ~2s, so always rebuild rather than track a wildcard of
@@ -30,7 +35,7 @@ build: check-deps | $(OUT_DIR)
 
 # Launch the widget in the simulator for manual testing.
 run: build simulator
-	monkeydo $(APP_PRG) $(DEVICE)
+	monkeydo $(APP_PRG) $(DEVICE) -a $(APP_SETTINGS):$(SETTINGS_DEST)
 
 # Compile with unit tests enabled, then run them in the simulator.
 # monkeydo exits non-zero on a clean PASSED run, so we grep the


### PR DESCRIPTION
## Summary

- **Fix:** `make run` now pushes the generated `*-settings.json` sidecar into the simulator at `GARMIN/Settings/<APP>-settings.json` via `monkeydo -a`. Without this push the simulator's **App Settings Editor** ("Settings → Edit Application Properties Data…") reports *"No settings file found for this app"* even though `resources/settings/settings.xml` is valid and the sidecar is generated correctly. The destination path was found in a Garmin forum thread — `monkeydo` doesn't push it by default, and the editor only reads from that exact vfs path.
- **Cleanup:** Honor `current-sdk.cfg` so `make` follows whichever SDK the SDK Manager has marked active (instead of whichever the brew symlinks happen to point at). Launch `ConnectIQ.app` via the active SDK's bundle so the running simulator matches the toolchain in PATH.
- **Cleanup:** Hoist the bundle name into `APP_NAME` and derive `APP_PRG`, `APP_SETTINGS`, `SETTINGS_DEST`, `TEST_PRG` from it.

## Test plan

- [x] `make clean && make build` succeeds
- [x] `make run` launches the widget and the App Settings Editor populates with all 5 settings (verified on Apple Silicon)
- [ ] `make test` still passes