### PR TITLE
docs: (:glance) trap + onUpdate refresh convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Entry point `source/App.mc` (`class App extends Application.AppBase`):
 1. `MoneyNotSpentView`
 2. `CleanSinceView`
 
-Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(nextPage)` — page state is held in the delegate, not globally. When adding a new stat view, update both `_numberOfViews` and the `switch` in `getView`.
+Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(nextPage)` — page state is held in the delegate, not globally. `NavigationBehavior.initialize` also writes the current page to `Application.Storage["lastPage"]`, and `App.getInitialView()` reads it back on launch so the widget reopens to where the user left off. When adding a new stat view, update both `_numberOfViews` and the `switch` in `getView`; the `default` case keeps stale stored values safe.
 
 **Stats module** (`source/stats/Stats.mc`) is pure functions over `Time.Moment`:
 
@@ -51,7 +51,9 @@ Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(
 - `ElapsedTimeBuilder` (`stats/ElapsedTimeBuilder.mc`) converts a `Time.Duration` into the `ElapsedTime` struct that views render.
 - `Milestones.mc` defines progress milestones.
 
-**Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG.md). Currency is an index into a fixed `currencySymbols` array of resource symbols (`:SignUSD`, `:SignEUR`, `:SignHUF`); add new currencies in both the array and the strings resources.
+**Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`, `colorSpace`. Every getter null-guards the underlying property read with a sensible default. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG.md). `getCurrencyConfig()` returns a dict `{:symbol, :suffixed, :priceFormat}` for the active currency — views consume this, not the raw index. To add a currency: append an entry to `getCurrencyConfig`'s `configs` table, add a string resource for the symbol, and add a `listEntry` in `settings.xml`.
+
+**Settings reactivity.** `App.onSettingsChanged` calls `WatchUi.requestUpdate()` so Connect-Mobile-pushed setting changes are visible without relaunch. This means **settings-dependent computation belongs in `onUpdate`, not `onShow`** — `onShow` is for one-time resource loads (icons, static strings). Each stat view follows this pattern: resources in `onShow`, settings reads + title computation in `onUpdate`.
 
 **Tests** live next to the code they cover as `*.tests.mc` files using Toybox `(:test)` modules. `source/utils/TestUtils.mc` and `source/stats/Stats.tests.mc` set up shared `today` / `quitDate` moments inside a `TestConsts` module.
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -13,3 +13,11 @@ Anchor: `source/stats/ElapsedTimeBuilder.mc`
 `365 / 12 == 30` because both operands are `Number`. If a constant looks fractional, it isn't unless one operand is forced to `Float`/`Double`: write `365.0 / 12` when you mean a real ratio. Constant names that imply fractions (`DAYS_IN_MONTH`, `AVG_…`, anything that sounds like a mean) without the matching type are a smell — verify the type before using them in proportional math.
 
 Anchor: `source/stats/Stats.mc`
+
+## Anything reachable from the glance build needs `(:glance)`
+
+The glance build is a separate, smaller binary than the full app, produced by stripping every function, class, and module that is not annotated `(:glance)`. The linker does **not** warn when a glance call site references stripped code — you get a silent broken binary that crashes at first invocation with `"Failed invoking <symbol>"`.
+
+Rule: every function that can be on the call path from a `(:glance)` class (transitively) must carry `(:glance)` itself. When in doubt, follow the chain from `GlanceView.onLayout` / `onUpdate` through every call and check each callee.
+
+Anchor: `source/Settings.mc` — `getColorSpace()` was missed during the v0.4.1 Settings refactor and crashed the glance view at launch until the annotation was added.


### PR DESCRIPTION
## Summary

Two cross-cutting things we learned during the v0.4.1 / PR #13 cycle that future contributors (and future-me) need on hand:

- **`docs/learnings.md`** — new entry: the glance build silently strips unannotated code; missing `(:glance)` produces a runtime "Failed invoking <symbol>" with no linker warning. Anchored on the `getColorSpace()` regression that crashed v0.4.1's first build.
- **`CLAUDE.md`** —
  - Refreshed the Settings paragraph (was stale: still described the pre-v0.4.1 `currencySymbols` array and didn't mention null-guards or `getCurrencyConfig`).
  - Added a **Settings reactivity** note: `App.onSettingsChanged` triggers `requestUpdate` (not `onShow`), so settings-dependent computation has to live in `onUpdate`. PR #13 made this the convention for all three stat views; this writes it down so future view authors don't put it in `onShow` and wonder why settings edits don't propagate.
  - Mentioned the last-page persistence wiring from PR #14.

Pure docs — no code or test changes.