### PR TITLE
Settings tests via PropertyReader DI seam

### DIFF
--- a/source/PropertyReader.mc
+++ b/source/PropertyReader.mc
@@ -1,0 +1,39 @@
+import Toybox.Application;
+import Toybox.Lang;
+
+(:glance)
+class PropertyReader {
+  function initialize() {}
+
+  function getValue(key as String) as Object? {
+    return null;
+  }
+}
+
+(:glance)
+class ApplicationPropertyReader extends PropertyReader {
+  function initialize() {
+    PropertyReader.initialize();
+  }
+
+  function getValue(key as String) as Object? {
+    return Properties.getValue(key);
+  }
+}
+
+(:test)
+class DictPropertyReader extends PropertyReader {
+  private var _values as Dictionary;
+
+  function initialize(values as Dictionary) {
+    PropertyReader.initialize();
+    _values = values;
+  }
+
+  function getValue(key as String) as Object? {
+    if (_values.hasKey(key)) {
+      return _values.get(key);
+    }
+    return null;
+  }
+}

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -4,29 +4,39 @@ import Toybox.Lang;
 
 module Settings {
 
+  var _reader as PropertyReader? = null;
+
+  (:glance)
+  function _getReader() as PropertyReader {
+    if (_reader == null) {
+      _reader = new ApplicationPropertyReader();
+    }
+    return _reader;
+  }
+
   public function getPackPrice() as Float {
-    var v = Properties.getValue("packPrice");
+    var v = _getReader().getValue("packPrice");
     return v != null ? (v as Float) : 9.0f;
   }
 
   public function getPackSize() as Number {
-    var v = Properties.getValue("packSize");
+    var v = _getReader().getValue("packSize");
     return v != null ? (v as Number) : 19;
   }
 
   public function getCigarettesPerDay() as Number {
-    var v = Properties.getValue("cigarettesPerDay");
+    var v = _getReader().getValue("cigarettesPerDay");
     return v != null ? (v as Number) : 1;
   }
 
   public function getCurrencyIndex() as Number {
-    var v = Properties.getValue("currency");
+    var v = _getReader().getValue("currency");
     return v != null ? (v as Number) : 0;
   }
 
   (:glance)
   public function getColorSpace() as Number {
-    var v = Properties.getValue("colorSpace");
+    var v = _getReader().getValue("colorSpace");
     return v != null ? (v as Number) : 0;
   }
 
@@ -42,12 +52,14 @@ module Settings {
 
   (:glance)
   public function getQuitDate() as Time.Moment {
-    var timestamp = Properties.getValue("quitDate");
-    // If the quit date is not set or is in the future, return today
+    var raw = _getReader().getValue("quitDate");
+    if (!(raw instanceof Lang.Number)) {
+      return new Time.Moment(Time.today().value());
+    }
+    var timestamp = raw as Number;
     if (timestamp == 0 || timestamp > Time.now().value()) {
       return new Time.Moment(Time.today().value());
     }
-
     return new Time.Moment(timestamp);
   }
 }

--- a/source/Settings.tests.mc
+++ b/source/Settings.tests.mc
@@ -1,0 +1,63 @@
+import Toybox.Test;
+import Toybox.Time;
+import Toybox.Lang;
+import Toybox.Application;
+
+import Settings;
+
+(:test)
+module SettingsTests {
+
+  // Test-only helper. Lives in this (:test) module so the wrapped seam stays
+  // out of production builds, and the test runner doesn't try to invoke it
+  // as a test (it isn't (:test)-annotated and doesn't take a Logger).
+  function _setReader(r as PropertyReader) as Void {
+    Settings._reader = r;
+  }
+
+  (:test)
+  function quitDate_returnsTodayWhenZero(logger as Logger) as Boolean {
+    _setReader(new DictPropertyReader({"quitDate" => 0}));
+    var got = Settings.getQuitDate();
+    return got.value() == Time.today().value();
+  }
+
+  (:test)
+  function quitDate_returnsTodayWhenInFuture(logger as Logger) as Boolean {
+    var future = Time.now().value() + 86400;
+    _setReader(new DictPropertyReader({"quitDate" => future}));
+    var got = Settings.getQuitDate();
+    return got.value() == Time.today().value();
+  }
+
+  (:test)
+  function quitDate_returnsStoredWhenPast(logger as Logger) as Boolean {
+    var past = Time.now().value() - 86400;
+    _setReader(new DictPropertyReader({"quitDate" => past}));
+    var got = Settings.getQuitDate();
+    return got.value() == past;
+  }
+
+  (:test)
+  function currencySymbol_outOfRangeFallsBackToUSD(logger as Logger) as Boolean {
+    _setReader(new DictPropertyReader({"currency" => 99}));
+    var got = Settings.getCurrencyConfig();
+    var expected = Application.loadResource(Rez.Strings.SignUSD) as String;
+    return got[:symbol].equals(expected);
+  }
+
+  (:test)
+  function currencySymbol_eachIndexReturnsExpectedResource(logger as Logger) as Boolean {
+    var keys = [Rez.Strings.SignUSD, Rez.Strings.SignEUR, Rez.Strings.SignHUF];
+    for (var i = 0; i < keys.size(); i++) {
+      _setReader(new DictPropertyReader({"currency" => i}));
+      var got = Settings.getCurrencyConfig();
+      var expected = Application.loadResource(keys[i]) as String;
+      if (!got[:symbol].equals(expected)) {
+        logger.debug(Lang.format("Currency $1$: expected '$2$', got '$3$'.", [i, expected, got[:symbol]]));
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the last Phase 1 (v0.5.0) item from the implementation plan.

- New `PropertyReader` base class with two subclasses:
  - `ApplicationPropertyReader` — production reader, wraps `Application.Properties.getValue`
  - `DictPropertyReader` — `(:test)`-only, returns values from a `Dictionary`
- `Settings` lazy-inits a reader on first use; every `Properties.getValue` call now goes through it.
- Uses regular virtual dispatch (`reader.getValue(key)`), **not** indirect method-pointer lookup via `:name`. The latter has known TVM issues on this platform.
- 5 new tests in `Settings.tests.mc`:
  - `quitDate_returnsTodayWhenZero`
  - `quitDate_returnsTodayWhenInFuture`
  - `quitDate_returnsStoredWhenPast`
  - `currencySymbol_outOfRangeFallsBackToUSD`
  - `currencySymbol_eachIndexReturnsExpectedResource`

## Test plan

- [x] `make test` — 33 tests pass (28 existing + 5 new)
- [x] `make build` — production build succeeds, glance path unchanged (only the pre-existing GlanceView.mc warning)