### PR TITLE
feat(view): native page indicator via WatchUi.ViewLoop

### DIFF
--- a/source/App.mc
+++ b/source/App.mc
@@ -28,8 +28,8 @@ class App extends Application.AppBase {
   function getInitialView() as [WatchUi.Views] or [WatchUi.Views, WatchUi.InputDelegates] {
     var stored = Application.Storage.getValue("lastPage");
     var page = stored instanceof Lang.Number ? stored : 0;
-    var nav = new NavigationBehavior(page);
-    return [nav.getView(page), nav] as [WatchUi.Views, WatchUi.InputDelegates];
+    var viewLoop = new WatchUi.ViewLoop(new StatLoopFactory(), {:page => page, :wrap => true});
+    return [viewLoop, new NavigationBehavior(viewLoop, page)] as [WatchUi.Views, WatchUi.InputDelegates];
   }
 
   function onSettingsChanged() as Void {

--- a/source/view/NavigationBehavior.mc
+++ b/source/view/NavigationBehavior.mc
@@ -1,41 +1,36 @@
 import Toybox.Application;
-import Toybox.WatchUi;
 import Toybox.Lang;
+import Toybox.WatchUi;
 
-class NavigationBehavior extends BehaviorDelegate {
+// Outer delegate for the page-loop ViewLoop. Handles MENU (push settings)
+// and persists the last-viewed page on every navigation.
+class NavigationBehavior extends WatchUi.ViewLoopDelegate {
+  private var _viewLoop as WatchUi.ViewLoop;
   private var _currentPage as Number;
   private const _numberOfViews as Number = 3;
 
-  function initialize(currentPage as Number) {
+  function initialize(viewLoop as WatchUi.ViewLoop, currentPage as Number) {
+    ViewLoopDelegate.initialize(viewLoop);
+    _viewLoop = viewLoop;
     _currentPage = currentPage;
-    Storage.setValue("lastPage", currentPage);
-    BehaviorDelegate.initialize();
   }
 
-  function onNextPage() as Boolean {
-    var nextPage = (_currentPage + 1) % _numberOfViews;
-    WatchUi.switchToView(getView(nextPage), new NavigationBehavior(nextPage), WatchUi.SLIDE_UP);
+  function onNextView() as Boolean {
+    _viewLoop.changeView(WatchUi.ViewLoop.DIRECTION_NEXT);
+    _currentPage = (_currentPage + 1) % _numberOfViews;
+    Storage.setValue("lastPage", _currentPage);
     return true;
   }
 
-  function onPreviousPage() as Boolean {
-    var prevPage = (_currentPage - 1 + _numberOfViews) % _numberOfViews;
-    WatchUi.switchToView(getView(prevPage), new NavigationBehavior(prevPage), WatchUi.SLIDE_DOWN);
+  function onPreviousView() as Boolean {
+    _viewLoop.changeView(WatchUi.ViewLoop.DIRECTION_PREVIOUS);
+    _currentPage = (_currentPage - 1 + _numberOfViews) % _numberOfViews;
+    Storage.setValue("lastPage", _currentPage);
     return true;
   }
 
   function onMenu() as Boolean {
     WatchUi.pushView(new SettingsMenu(), new SettingsMenuDelegate(), WatchUi.SLIDE_UP);
     return true;
-  }
-
-  // To add a view: add a case here and increment _numberOfViews.
-  function getView(page as Number) as WatchUi.View {
-    switch (page) {
-      case 0: return new CigarettesNotSmokedView();
-      case 1: return new MoneyNotSpentView();
-      case 2: return new CleanSinceView();
-      default: return new CigarettesNotSmokedView();
-    }
   }
 }

--- a/source/view/StatLoopFactory.mc
+++ b/source/view/StatLoopFactory.mc
@@ -1,0 +1,32 @@
+import Toybox.Lang;
+import Toybox.WatchUi;
+
+// Provides the three stat views to the WatchUi.ViewLoop, which then draws
+// the native page indicator on the left bezel and handles transitions.
+// Garmin reconstructs the view each time you navigate, so views must not
+// hold session state across navigations — ours read everything fresh from
+// Settings in onUpdate, so re-construction is cheap.
+class StatLoopFactory extends WatchUi.ViewLoopFactory {
+  public const NUM_PAGES as Number = 3;
+
+  function initialize() {
+    ViewLoopFactory.initialize();
+  }
+
+  function getView(page as Number) {
+    return [_viewForPage(page), new WatchUi.BehaviorDelegate()];
+  }
+
+  function getSize() as Number {
+    return NUM_PAGES;
+  }
+
+  private function _viewForPage(page as Number) as WatchUi.View {
+    switch (page) {
+      case 0: return new CigarettesNotSmokedView();
+      case 1: return new MoneyNotSpentView();
+      case 2: return new CleanSinceView();
+      default: return new CigarettesNotSmokedView();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Switch the stat-view page navigation from `BehaviorDelegate` + `switchToView` to `WatchUi.ViewLoop` (API 3.4.0+). The system now draws the device's native page indicator on the left bezel automatically — no custom drawing.

## Status

🟡 **Draft.** Open questions before merging:

https://forums.garmin.com/developer/connect-iq/i/bug-reports/feature-request-align-viewloop-look-and-feel-with-current-garmin-widgets

https://forums.garmin.com/developer/connect-iq/f/discussion/417812/do-we-have-access-to-the-dots-on-left-of-the-screen-when-there-are-multiple-pages-to-scroll-through

- The simulator (SDK 9.1) renders the indicator as an arc on both fenix 6 and fenix 7, not dots — needs verification on real hardware to know what the actual fenix 6 device shows.
- The indicator style is hardcoded per Garmin's "personality library"; `ViewLoop` options are limited to `:page`, `:wrap`, `:color`. No way to override the shape.
- If the real device shows the wrong indicator (or doesn't match the user's expectation), the fallback is to revert to the custom dot overlay we had in an earlier branch.

## Changes

- New `source/view/StatLoopFactory.mc` — `ViewLoopFactory` returning the three stat views.
- `source/view/NavigationBehavior.mc` — now extends `ViewLoopDelegate`; tracks current page so `Storage["lastPage"]` keeps working; `onMenu` still pushes the settings menu.
- `source/App.mc` — `getInitialView` builds the `ViewLoop` with `:page` from storage and `:wrap => true`.

## Test plan

- [x] `make build` clean on fenix6
- [x] App runs in the simulator without crash (after fixing `getView` to return `[view, delegate]`)
- [ ] Verify the indicator on a real fenix 6
- [ ] Verify settings menu still opens via MENU button on a real fenix 6
- [ ] Verify last-viewed page persists across relaunch