### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-23
+
 ### Added
 
 - The widget now remembers the last-viewed stat page and reopens to it on next launch.
@@ -72,7 +74,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 First test release to Connect IQ Store to test app settings
 
-[unreleased]: https://github.com/Zmetser/SmokeFreeCompanion/compare/v0.4.1...HEAD
+[unreleased]: https://github.com/Zmetser/SmokeFreeCompanion/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Zmetser/SmokeFreeCompanion/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Zmetser/SmokeFreeCompanion/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Zmetser/SmokeFreeCompanion/releases/tag/v0.4.0
 [0.3.0]: https://github.com/Zmetser/SmokeFreeCompanion/releases/tag/v0.3.0

--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,5 +1,5 @@
 <properties>
-  <property id="appVersion" type="string">0.4.1</property>
+  <property id="appVersion" type="string">0.5.0</property>
   <property id="quitDate" type="number">0</property>
   <property id="currency" type="number">0</property>
   <property id="packPrice" type="double">9.0</property>


### PR DESCRIPTION
Release prep for v0.5.0.

- [x] CHANGELOG: moved [Unreleased] to [0.5.0] - 2026-05-23
- [x] CHANGELOG: updated anchors ([unreleased] now compares against v0.5.0; added [0.5.0])
- [x] Bumped \`appVersion\` property to 0.5.0
- [x] Built \`releases/0.5.0/SmokeFreeCompanion.iq\` locally (gitignored — for Connect IQ Store upload)

## After merge

- [ ] Tag \`v0.5.0\` on the merge commit and push tag
- [ ] Upload \`releases/0.5.0/SmokeFreeCompanion.iq\` to the Connect IQ Store
- [ ] Create the GitHub release pointing at \`v0.5.0\` with the changelog excerpt