### PR TITLE
chore(makefile): point DEVELOPER_KEY at the store-registered key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Override on the command line, e.g. `make test DEVICE=fenix7`
 DEVICE       ?= fenix6
-DEVELOPER_KEY ?= $(HOME)/.garmin/developer_key.der
+DEVELOPER_KEY ?= $(HOME)/.garmin/developer_key
 OUT_DIR      ?= out
 JUNGLE       ?= monkey.jungle
 


### PR DESCRIPTION
The Makefile's default key path pointed at \`~/.garmin/developer_key.der\`, but that file is a legacy key that no longer matches the signing key registered with the Connect IQ Store for this app. Uploading the v0.5.0 build signed with it failed:

> Signature check has failed. All app versions must be signed with the same key pair.

The actual active key is \`~/.garmin/developer_key\` (no extension). Both files are still on disk locally; this PR just flips the default so future \`make build\` / \`make release\` runs produce store-uploadable binaries by default.

Verified locally: \`make build\` on fenix6 produces a working .prg with the new default.