### PR TITLE
feat(milestones): MilestonesView with NHS descriptions and motivational variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- New **Milestones** page as the widget's landing view: shows a circular progress arc with an `elapsed / target` fraction (e.g. `23h / 48h`, `60d / 12w`, `260d / 1y`) toward the next NHS milestone.
+- Each of the 6 NHS milestone bands (24h, 48h, 72h, weeks, months, 1y+) carries a paraphrased physiological description; repeat visits to the same band swap in one of two band-specific motivational lines so the page rewards return visits.
+- Hungarian translations for all new milestone copy.
+
+### Changed
+
+- Milestone set rebalanced to a curated 10-entry list (`24h, 48h, 72h, 1w, 2w, 4w, 12w, 6mo, 9mo, 1y`) replacing the previous 31-entry array.
+
 ## [0.5.0] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,15 @@ Single-test runs are not supported by either path; `monkeydo -t` runs every `(:t
 
 Entry point `source/App.mc` (`class App extends Application.AppBase`):
 
-- `getInitialView()` returns `CigarettesNotSmokedView` paired with a `NavigationBehavior(0)` delegate.
+- `getInitialView()` reads `Application.Storage["lastPage"]` and returns the matching view via `NavigationBehavior.getView(page)`. On a fresh install the default is page 0 (`MilestonesView`).
 - `getGlanceView()` returns `GlanceView` — the compact widget preview. Code reachable from the glance must be annotated `(:glance)` (see `App`, `Settings.getQuitDate`, `Stats.durationSince`, `Stats.elapsedTimeSince`).
 
-**View paging.** `source/view/NavigationBehavior.mc` is a `BehaviorDelegate` that cycles through 3 stat views via `onNextPage` / `onPreviousPage`, hard-coded in `getView(page)`:
+**View paging.** `source/view/NavigationBehavior.mc` is a `BehaviorDelegate` that cycles through 4 stat views via `onNextPage` / `onPreviousPage`, hard-coded in `getView(page)`:
 
-0. `CigarettesNotSmokedView`
-1. `MoneyNotSpentView`
-2. `CleanSinceView`
+0. `MilestonesView`
+1. `CigarettesNotSmokedView`
+2. `MoneyNotSpentView`
+3. `CleanSinceView`
 
 Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(nextPage)` — page state is held in the delegate, not globally. `NavigationBehavior.initialize` also writes the current page to `Application.Storage["lastPage"]`, and `App.getInitialView()` reads it back on launch so the widget reopens to where the user left off. When adding a new stat view, update both `_numberOfViews` and the `switch` in `getView`; the `default` case keeps stale stored values safe.
 
@@ -49,7 +50,7 @@ Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(
 - `durationSince`, `elapsedTimeSince` — used by glance and views.
 - `cigarettesNotSmoked` works in **hours**, not days (`cigarettesPerDay / 24` × duration-in-hours). This was a deliberate change in v0.4.0 for finer-grained updates; preserve hour-level math when modifying.
 - `ElapsedTimeBuilder` (`stats/ElapsedTimeBuilder.mc`) converts a `Time.Duration` into the `ElapsedTime` struct that views render.
-- `Milestones.mc` defines progress milestones.
+- `Milestones.mc` defines the 10-entry `MILESTONES` array (`24h..1y`) plus `closestMilestoneTo`, `milestoneProgress`, `labelFor` (hours/days/weeks/months/years), `elapsedDivisorFor` + `elapsedUnitFor` (one tier finer than the target so the view can render `"60d / 12w"` rather than `"0 / 1y"`), and `bandIndexFor` (maps a target milestone to one of 6 NHS description bands for `MilestonesView`).
 
 **Settings** (`source/Settings.mc`) wraps `Application.Properties` for `packPrice`, `packSize`, `cigarettesPerDay`, `quitDate`, `currency`, `colorSpace`. Every getter null-guards the underlying property read with a sensible default. Property keys are defined in `resources/settings/properties.xml` and surfaced to users via `resources/settings/settings.xml`. `getQuitDate()` falls back to today when the stored timestamp is `0` or in the future (handles the pre-1970 / future-date edge cases called out in CHANGELOG.md). `getCurrencyConfig()` returns a dict `{:symbol, :suffixed, :priceFormat, :defaultPrice, :pickerMode}` for the active currency — views and the on-watch price picker consume this, not the raw index. `:pickerMode` is one of `:narrow` (USD/EUR: 2 int + "." + 1 decimal, max 99.9) or `:hundreds` (HUF: 2 int + literal "00.0", max 9900 step 100). To add a currency: append an entry to `getCurrencyConfig`'s `configs` table (including `:defaultPrice` and `:pickerMode`), add a string resource for the symbol, and add a `listEntry` in `settings.xml`.
 
@@ -57,7 +58,9 @@ Each transition calls `WatchUi.switchToView` with a **new** `NavigationBehavior(
 
 **On-watch editing.** Long-press UP (the MENU behavior) on any stat view opens `SettingsMenu` (`source/settings/SettingsMenu.mc`) via `NavigationBehavior.onMenu`. Editors live in the same folder: `CurrencyMenu` for the list pick, `Pickers.mc` for the three `WatchUi.Picker`s (whole-number, currency-aware price, date). The price picker layout branches on `currencyConfig[:pickerMode]`. Setters in `Settings.mc` write through `Properties.setValue` via the same `PropertyReader` DI seam the getters use, so unit tests round-trip without hitting real Properties. Changing currency in `CurrencyMenu` also resets `packPrice` to the new currency's `:defaultPrice` so the user isn't left with a price at the wrong scale.
 
-**Upgrade compatibility — load-bearing.** The current Store release is **v0.4.0**; existing users have real configured values in `Application.Properties` on their devices. Property **keys** and **types** in `resources/settings/properties.xml` (and the corresponding casts in `Settings.mc`) are an external contract — changing or removing any of `quitDate` (number), `currency` (number), `packPrice` (double), `cigarettesPerDay` (number), `packSize` (number) silently wipes the value for every existing user on update. If a key or type must change, ship an explicit migration that reads the old key and writes the new one before the first getter is called. The regression guard is `SettingsTests.upgradeFromV040_preservesAllUserSettings` in `source/Settings.tests.mc` — keep it green.
+**MilestonesView** (`source/view/MilestonesView.mc`) shows progress toward the next NHS milestone as a `CircularProgressBar` arc plus an `elapsed / target` fraction (e.g. `"23h / 48h"`). Below the fraction a `WatchUi.TextArea` renders one of three description strings for the current band: an NHS-paraphrased physiological fact on the user's first visit to that band, then a random pick from `{NHS, motivational #1, motivational #2}` on repeat visits. First-visit tracking is a 6-bit bitfield in `Application.Storage["milestonesBandsSeen"]` (one bit per band, unset reads as 0 so v0.5.0 upgraders see the NHS copy first like a fresh install). Entry animation is a 700ms ease-out arc sweep driven by `System.getTimer()` inside `onUpdate` calling `WatchUi.requestUpdate()` until done — `Timer.Timer` is not used here because instance `method(:name)` indirect lookup crashes the simulator TVM (see `learning_monkeyc_indirect_method_lookup`).
+
+**Upgrade compatibility — load-bearing.** The current Store release is **v0.5.0**; existing users have real configured values in `Application.Properties` on their devices. Property **keys** and **types** in `resources/settings/properties.xml` (and the corresponding casts in `Settings.mc`) are an external contract — changing or removing any of `quitDate` (number), `currency` (number), `packPrice` (double), `cigarettesPerDay` (number), `packSize` (number) silently wipes the value for every existing user on update. If a key or type must change, ship an explicit migration that reads the old key and writes the new one before the first getter is called. The regression guard is `SettingsTests.upgradeFromV040_preservesAllUserSettings` in `source/Settings.tests.mc` — keep it green.
 
 Note: v0.4.0's `Settings.mc` had no null-guards and stricter `as Number` casts; the current null-guard-everything pattern is strictly more permissive, so any value a v0.4.0 user could have stored is readable by today's code.
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -14,6 +14,14 @@ Anchor: `source/stats/ElapsedTimeBuilder.mc`
 
 Anchor: `source/stats/Stats.mc`
 
+## `FONT_NUMBER_*` fonts are digits-only
+
+Every `Graphics.FONT_NUMBER_*` variant (`FONT_NUMBER_MILD`, `FONT_NUMBER_MEDIUM`, `FONT_NUMBER_HOT`, `FONT_NUMBER_THAI_HOT`) ships only digit glyphs and a handful of separators — letters render as the missing-glyph box. `StatView.drawTitle` uses `FONT_NUMBER_MEDIUM` because the stat titles are numeric; any subclass whose title carries a letter (unit suffix, abbreviation, label) must override `drawTitle` to pick a letter-capable font like `FONT_LARGE` or `FONT_MEDIUM`.
+
+Rule: if a font name contains `NUMBER`, treat it as digits-only. Reach for `FONT_TINY` / `FONT_SMALL` / `FONT_MEDIUM` / `FONT_LARGE` when the text includes anything else.
+
+Anchor: `source/view/MilestonesView.drawTitle` — the milestone label "1d" rendered as `1` + tofu under the inherited `FONT_NUMBER_MEDIUM` until the override landed.
+
 ## Anything reachable from the glance build needs `(:glance)`
 
 The glance build is a separate, smaller binary than the full app, produced by stripping every function, class, and module that is not annotated `(:glance)`. The linker does **not** warn when a glance call site references stripped code — you get a silent broken binary that crashes at first invocation with `"Failed invoking <symbol>"`.

--- a/resources-hun/strings.xml
+++ b/resources-hun/strings.xml
@@ -22,25 +22,25 @@
   <string id="Milestones_UnitWeek">hét</string>
   <string id="Milestones_UnitMonth">hó</string>
   <string id="Milestones_UnitYear">é</string>
-  <!-- NHS-derived descriptions, paraphrased — TODO: native review -->
+  <!-- NHS-derived descriptions, paraphrased -->
   <string id="Milestones_Desc_24h">Az oxigénszinted javul, a szén-monoxid csökken.</string>
   <string id="Milestones_Desc_48h">A tüdő tisztul. Az ízlelés és szaglás javul.</string>
   <string id="Milestones_Desc_72h">A légzésed könnyebb. Energiád növekszik.</string>
   <string id="Milestones_Desc_Weeks">A vérkeringésed javul.</string>
   <string id="Milestones_Desc_Months">Tüdőfunkció akár 10%-kal jobb. A köhögés enyhül.</string>
   <string id="Milestones_Desc_1y">A szívinfarktus kockázata felére csökkent.</string>
-  <!-- Motivational variants — TODO: native review -->
-  <string id="Milestones_Mot_24h_1">Megcsináltad — 24 óra cigi nélkül.</string>
-  <string id="Milestones_Mot_24h_2">Az első nap a legnehezebb. Bírod!</string>
-  <string id="Milestones_Mot_48h_1">Két nap friss levegő. Csak így tovább.</string>
+  <!-- Motivational variants -->
+  <string id="Milestones_Mot_24h_1">Hidd el, hogy menni fog — már félúton vagy.</string>
+  <string id="Milestones_Mot_24h_2">Hiszek benned. Egyszerre csak egy óra.</string>
+  <string id="Milestones_Mot_48h_1">Megcsináltad — 24 óra cigi nélkül.</string>
   <string id="Milestones_Mot_48h_2">A tested most hálás neked.</string>
-  <string id="Milestones_Mot_72h_1">Három nap! Új szokásokat építesz.</string>
+  <string id="Milestones_Mot_72h_1">Két nap friss levegő. Csak így tovább.</string>
   <string id="Milestones_Mot_72h_2">A sóvárgás kezd elgyengülni.</string>
   <string id="Milestones_Mot_Weeks_1">Fantasztikus vagy. Tarts ki.</string>
   <string id="Milestones_Mot_Weeks_2">Minden lélegzet a tiéd.</string>
-  <string id="Milestones_Mot_Months_1">Hónapok szabadság. Légy büszke.</string>
+  <string id="Milestones_Mot_Months_1">A sóvárgás múló. A szabadság örök.</string>
   <string id="Milestones_Mot_Months_2">Nézd, milyen messzire jutottál.</string>
-  <string id="Milestones_Mot_1y_1">Egy egész év. Ünnepeld meg.</string>
+  <string id="Milestones_Mot_1y_1">Erősebb vagy, mint a függőséged.</string>
   <string id="Milestones_Mot_1y_2">Megcsináltad a nehezét.</string>
 
   <!-- Quit Data Screen -->

--- a/resources-hun/strings.xml
+++ b/resources-hun/strings.xml
@@ -6,6 +6,7 @@
 
   <string id="CigarettesPerDay">Szál cigaretta naponta</string>
   <string id="QuitDate">Leszokás dátuma</string>
+  <string id="QuitTime">Leszokás ideje</string>
   <string id="PackPrice">Doboz ára</string>
   <string id="PackSize">Szál cigaretta 1 dobozban</string>
 
@@ -17,12 +18,15 @@
   <string id="ShortMinute" scope="glance">p</string>
   
   <!-- Milestones screen -->
+  <string id="Milestones_UnitMinute">p</string>
   <string id="Milestones_UnitHour">ó</string>
   <string id="Milestones_UnitDay">n</string>
   <string id="Milestones_UnitWeek">hét</string>
   <string id="Milestones_UnitMonth">hó</string>
   <string id="Milestones_UnitYear">é</string>
   <!-- NHS-derived descriptions, paraphrased -->
+  <string id="Milestones_Desc_20min">A pulzusod kezd visszaállni a normálisra.</string>
+  <string id="Milestones_Desc_8h">Az oxigénszinted javul. A szén-monoxid felére csökkent.</string>
   <string id="Milestones_Desc_24h">Az oxigénszinted javul, a szén-monoxid csökken.</string>
   <string id="Milestones_Desc_48h">A tüdő tisztul. Az ízlelés és szaglás javul.</string>
   <string id="Milestones_Desc_72h">A légzésed könnyebb. Energiád növekszik.</string>
@@ -30,6 +34,10 @@
   <string id="Milestones_Desc_Months">Tüdőfunkció akár 10%-kal jobb. A köhögés enyhül.</string>
   <string id="Milestones_Desc_1y">A szívinfarktus kockázata felére csökkent.</string>
   <!-- Motivational variants -->
+  <string id="Milestones_Mot_20min_1">Az első 20 perc — a tested már észrevette.</string>
+  <string id="Milestones_Mot_20min_2">Most kezdődik valami jó.</string>
+  <string id="Milestones_Mot_8h_1">Nyolc óra mögötted. Csendben nyerésben vagy.</string>
+  <string id="Milestones_Mot_8h_2">A szén-monoxid fele már eltűnt.</string>
   <string id="Milestones_Mot_24h_1">Hidd el, hogy menni fog — már félúton vagy.</string>
   <string id="Milestones_Mot_24h_2">Hiszek benned. Egyszerre csak egy óra.</string>
   <string id="Milestones_Mot_48h_1">Megcsináltad — 24 óra cigi nélkül.</string>

--- a/resources-hun/strings.xml
+++ b/resources-hun/strings.xml
@@ -16,6 +16,33 @@
   <string id="ShortHour" scope="glance">ó</string>
   <string id="ShortMinute" scope="glance">p</string>
   
+  <!-- Milestones screen -->
+  <string id="Milestones_UnitHour">ó</string>
+  <string id="Milestones_UnitDay">n</string>
+  <string id="Milestones_UnitWeek">hét</string>
+  <string id="Milestones_UnitMonth">hó</string>
+  <string id="Milestones_UnitYear">é</string>
+  <!-- NHS-derived descriptions, paraphrased — TODO: native review -->
+  <string id="Milestones_Desc_24h">Az oxigénszinted javul, a szén-monoxid csökken.</string>
+  <string id="Milestones_Desc_48h">A tüdő tisztul. Az ízlelés és szaglás javul.</string>
+  <string id="Milestones_Desc_72h">A légzésed könnyebb. Energiád növekszik.</string>
+  <string id="Milestones_Desc_Weeks">A vérkeringésed javul.</string>
+  <string id="Milestones_Desc_Months">Tüdőfunkció akár 10%-kal jobb. A köhögés enyhül.</string>
+  <string id="Milestones_Desc_1y">A szívinfarktus kockázata felére csökkent.</string>
+  <!-- Motivational variants — TODO: native review -->
+  <string id="Milestones_Mot_24h_1">Megcsináltad — 24 óra cigi nélkül.</string>
+  <string id="Milestones_Mot_24h_2">Az első nap a legnehezebb. Bírod!</string>
+  <string id="Milestones_Mot_48h_1">Két nap friss levegő. Csak így tovább.</string>
+  <string id="Milestones_Mot_48h_2">A tested most hálás neked.</string>
+  <string id="Milestones_Mot_72h_1">Három nap! Új szokásokat építesz.</string>
+  <string id="Milestones_Mot_72h_2">A sóvárgás kezd elgyengülni.</string>
+  <string id="Milestones_Mot_Weeks_1">Fantasztikus vagy. Tarts ki.</string>
+  <string id="Milestones_Mot_Weeks_2">Minden lélegzet a tiéd.</string>
+  <string id="Milestones_Mot_Months_1">Hónapok szabadság. Légy büszke.</string>
+  <string id="Milestones_Mot_Months_2">Nézd, milyen messzire jutottál.</string>
+  <string id="Milestones_Mot_1y_1">Egy egész év. Ünnepeld meg.</string>
+  <string id="Milestones_Mot_1y_2">Megcsináltad a nehezét.</string>
+
   <!-- Quit Data Screen -->
   <string id="Quit_OneDayTitle">Ma tetted le.</string>
   <string id="Quit_OneDaySubtitle">Gratulálok!</string>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -9,6 +9,7 @@
 
   <string id="CigarettesPerDay">Cigarettes Per Day</string>
   <string id="QuitDate">Quit Date</string>
+  <string id="QuitTime">Quit Time</string>
   <string id="PackPrice">Pack Price</string>
   <string id="PackSize">Cigarettes per Pack</string>
 
@@ -25,12 +26,15 @@
   <string id="SignHUF" translatable="false">Ft</string>
   
   <!-- Milestones screen -->
+  <string id="Milestones_UnitMinute">min</string>
   <string id="Milestones_UnitHour">h</string>
   <string id="Milestones_UnitDay">d</string>
   <string id="Milestones_UnitWeek">w</string>
   <string id="Milestones_UnitMonth">mo</string>
   <string id="Milestones_UnitYear">y</string>
   <!-- NHS-derived descriptions, paraphrased -->
+  <string id="Milestones_Desc_20min">Pulse rate starting to return to normal.</string>
+  <string id="Milestones_Desc_8h">Oxygen levels recovering. Carbon monoxide already halved.</string>
   <string id="Milestones_Desc_24h">Oxygen recovering, harmful carbon monoxide dropping.</string>
   <string id="Milestones_Desc_48h">Lungs clearing mucus. Taste and smell improving.</string>
   <string id="Milestones_Desc_72h">Breathing feels easier. Energy increasing.</string>
@@ -38,6 +42,10 @@
   <string id="Milestones_Desc_Months">Lung function up to 10% better. Coughing easing.</string>
   <string id="Milestones_Desc_1y">Heart attack risk has halved.</string>
   <!-- Motivational variants — shown on repeat visits to a band -->
+  <string id="Milestones_Mot_20min_1">The first 20 minutes — your body already noticed.</string>
+  <string id="Milestones_Mot_20min_2">Right now is the start of something good.</string>
+  <string id="Milestones_Mot_8h_1">Eight hours in. Quietly winning.</string>
+  <string id="Milestones_Mot_8h_2">Half the carbon monoxide is already gone.</string>
   <string id="Milestones_Mot_24h_1">Believe you can and you're halfway there.</string>
   <string id="Milestones_Mot_24h_2">I believe in you. One hour at a time.</string>
   <string id="Milestones_Mot_48h_1">You did it! 24 hours smoke-free.</string>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -38,17 +38,17 @@
   <string id="Milestones_Desc_Months">Lung function up to 10% better. Coughing easing.</string>
   <string id="Milestones_Desc_1y">Heart attack risk has halved.</string>
   <!-- Motivational variants — shown on repeat visits to a band -->
-  <string id="Milestones_Mot_24h_1">You did it — 24 hours smoke-free.</string>
-  <string id="Milestones_Mot_24h_2">Day one is the hardest. You're crushing it.</string>
-  <string id="Milestones_Mot_48h_1">Two days of fresh air. Keep going.</string>
+  <string id="Milestones_Mot_24h_1">Believe you can and you're halfway there.</string>
+  <string id="Milestones_Mot_24h_2">I believe in you. One hour at a time.</string>
+  <string id="Milestones_Mot_48h_1">You did it! 24 hours smoke-free.</string>
   <string id="Milestones_Mot_48h_2">Your body is thanking you right now.</string>
-  <string id="Milestones_Mot_72h_1">Three days strong. You're rewriting habits.</string>
+  <string id="Milestones_Mot_72h_1">Two days of fresh air. Keep going.</string>
   <string id="Milestones_Mot_72h_2">The cravings are losing their grip.</string>
   <string id="Milestones_Mot_Weeks_1">You're doing amazing. Stay with it.</string>
   <string id="Milestones_Mot_Weeks_2">Every breath is yours now.</string>
-  <string id="Milestones_Mot_Months_1">Months of freedom. Be proud.</string>
+  <string id="Milestones_Mot_Months_1">Cravings are temporary. Freedom is forever.</string>
   <string id="Milestones_Mot_Months_2">Look how far you've come.</string>
-  <string id="Milestones_Mot_1y_1">A whole year. Take a moment to celebrate.</string>
+  <string id="Milestones_Mot_1y_1">You are stronger than your addiction.</string>
   <string id="Milestones_Mot_1y_2">You did the hard thing.</string>
 
   <!-- Quit Data Screen -->

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -24,6 +24,33 @@
   <string id="SignEUR" translatable="false">€</string>
   <string id="SignHUF" translatable="false">Ft</string>
   
+  <!-- Milestones screen -->
+  <string id="Milestones_UnitHour">h</string>
+  <string id="Milestones_UnitDay">d</string>
+  <string id="Milestones_UnitWeek">w</string>
+  <string id="Milestones_UnitMonth">mo</string>
+  <string id="Milestones_UnitYear">y</string>
+  <!-- NHS-derived descriptions, paraphrased -->
+  <string id="Milestones_Desc_24h">Oxygen recovering, harmful carbon monoxide dropping.</string>
+  <string id="Milestones_Desc_48h">Lungs clearing mucus. Taste and smell improving.</string>
+  <string id="Milestones_Desc_72h">Breathing feels easier. Energy increasing.</string>
+  <string id="Milestones_Desc_Weeks">Blood circulation is improving.</string>
+  <string id="Milestones_Desc_Months">Lung function up to 10% better. Coughing easing.</string>
+  <string id="Milestones_Desc_1y">Heart attack risk has halved.</string>
+  <!-- Motivational variants — shown on repeat visits to a band -->
+  <string id="Milestones_Mot_24h_1">You did it — 24 hours smoke-free.</string>
+  <string id="Milestones_Mot_24h_2">Day one is the hardest. You're crushing it.</string>
+  <string id="Milestones_Mot_48h_1">Two days of fresh air. Keep going.</string>
+  <string id="Milestones_Mot_48h_2">Your body is thanking you right now.</string>
+  <string id="Milestones_Mot_72h_1">Three days strong. You're rewriting habits.</string>
+  <string id="Milestones_Mot_72h_2">The cravings are losing their grip.</string>
+  <string id="Milestones_Mot_Weeks_1">You're doing amazing. Stay with it.</string>
+  <string id="Milestones_Mot_Weeks_2">Every breath is yours now.</string>
+  <string id="Milestones_Mot_Months_1">Months of freedom. Be proud.</string>
+  <string id="Milestones_Mot_Months_2">Look how far you've come.</string>
+  <string id="Milestones_Mot_1y_1">A whole year. Take a moment to celebrate.</string>
+  <string id="Milestones_Mot_1y_2">You did the hard thing.</string>
+
   <!-- Quit Data Screen -->
   <string id="Quit_OneDayTitle">You quit today!</string>
   <string id="Quit_OneDaySubtitle">Congratulations!</string>

--- a/source/settings/Pickers.mc
+++ b/source/settings/Pickers.mc
@@ -137,6 +137,23 @@ class DatePicker extends WatchUi.Picker {
   }
 }
 
+class TimePicker extends WatchUi.Picker {
+  function initialize(title as String, defaultHour as Number, defaultMinute as Number) {
+    var font = Graphics.FONT_NUMBER_MILD;
+    var hourFactory = new WholeNumberFactory(0, 23, "%02d", font);
+    var minuteFactory = new WholeNumberFactory(0, 59, "%02d", font);
+    Picker.initialize({
+      :title => _titleDrawable(title),
+      :pattern => [hourFactory, _textDrawable(":", font), minuteFactory],
+      :defaults => [
+        hourFactory.getIndex(defaultHour),
+        0,
+        minuteFactory.getIndex(defaultMinute),
+      ],
+    });
+  }
+}
+
 function _titleDrawable(text as String) as WatchUi.Text {
   return new WatchUi.Text({
     :text => text,
@@ -212,18 +229,61 @@ class PackPricePickerDelegate extends WatchUi.PickerDelegate {
   }
 }
 
+// Quit date picker chains into the time picker on accept — the user always
+// sets both together so sub-day milestones (20min, 8h) have something to
+// count against. The QuitTimePickerDelegate is what actually writes Settings.
 class QuitDatePickerDelegate extends WatchUi.PickerDelegate {
   function initialize() {
     PickerDelegate.initialize();
   }
 
   function onAccept(values as Array) as Boolean {
+    var year = values[0] as Number;
+    var month = values[1] as Number;
+    var day = values[2] as Number;
+
+    var existing = Gregorian.info(Settings.getQuitDate(), Time.FORMAT_SHORT);
+    var defaultHour = existing.hour as Number;
+    var defaultMinute = existing.min as Number;
+
+    WatchUi.popView(WatchUi.SLIDE_DOWN);
+    WatchUi.pushView(
+      new TimePicker(
+        Application.loadResource(Rez.Strings.QuitTime) as String,
+        defaultHour,
+        defaultMinute
+      ),
+      new QuitTimePickerDelegate(year, month, day),
+      WatchUi.SLIDE_UP
+    );
+    return true;
+  }
+
+  function onCancel() as Boolean {
+    WatchUi.popView(WatchUi.SLIDE_DOWN);
+    return true;
+  }
+}
+
+class QuitTimePickerDelegate extends WatchUi.PickerDelegate {
+  private var _year as Number;
+  private var _month as Number;
+  private var _day as Number;
+
+  function initialize(year as Number, month as Number, day as Number) {
+    PickerDelegate.initialize();
+    _year = year;
+    _month = month;
+    _day = day;
+  }
+
+  function onAccept(values as Array) as Boolean {
     var moment = Gregorian.moment({
-      :year => values[0] as Number,
-      :month => values[1] as Number,
-      :day => values[2] as Number,
-      :hour => 0,
-      :minute => 0,
+      :year => _year,
+      :month => _month,
+      :day => _day,
+      :hour => values[0] as Number,
+      :minute => values[2] as Number,
       :second => 0,
     });
     Settings.setQuitDate(moment);

--- a/source/stats/Milestones.mc
+++ b/source/stats/Milestones.mc
@@ -7,38 +7,17 @@ import Stats;
 
 module Milestones {
   (:glance)
-	const MILESTONES = [
-    Gregorian.SECONDS_PER_DAY,
-    2 * Gregorian.SECONDS_PER_DAY,
-    3 * Gregorian.SECONDS_PER_DAY,
-    4 * Gregorian.SECONDS_PER_DAY,
-    5 * Gregorian.SECONDS_PER_DAY,
-    6 * Gregorian.SECONDS_PER_DAY,
-    7 * Gregorian.SECONDS_PER_DAY,
-    10 * Gregorian.SECONDS_PER_DAY,
-    14 * Gregorian.SECONDS_PER_DAY,
-    21 * Gregorian.SECONDS_PER_DAY,
-    30 * Gregorian.SECONDS_PER_DAY,
-    3 * 30 * Gregorian.SECONDS_PER_DAY,
-    Gregorian.SECONDS_PER_YEAR / 2,
-    Gregorian.SECONDS_PER_YEAR,
-    2 * Gregorian.SECONDS_PER_YEAR,
-    3 * Gregorian.SECONDS_PER_YEAR,
-    4 * Gregorian.SECONDS_PER_YEAR,
-    5 * Gregorian.SECONDS_PER_YEAR,
-    6 * Gregorian.SECONDS_PER_YEAR,
-    7 * Gregorian.SECONDS_PER_YEAR,
-    8 * Gregorian.SECONDS_PER_YEAR,
-    9 * Gregorian.SECONDS_PER_YEAR,
-    10 * Gregorian.SECONDS_PER_YEAR,
-    15 * Gregorian.SECONDS_PER_YEAR,
-    20 * Gregorian.SECONDS_PER_YEAR,
-    25 * Gregorian.SECONDS_PER_YEAR,
-    30 * Gregorian.SECONDS_PER_YEAR,
-    35 * Gregorian.SECONDS_PER_YEAR,
-    40 * Gregorian.SECONDS_PER_YEAR,
-    45 * Gregorian.SECONDS_PER_YEAR,
-    50 * Gregorian.SECONDS_PER_YEAR
+  const MILESTONES = [
+    Gregorian.SECONDS_PER_DAY,            // 24h
+    2 * Gregorian.SECONDS_PER_DAY,        // 48h
+    3 * Gregorian.SECONDS_PER_DAY,        // 72h
+    7 * Gregorian.SECONDS_PER_DAY,        // 1w
+    14 * Gregorian.SECONDS_PER_DAY,       // 2w
+    28 * Gregorian.SECONDS_PER_DAY,       // 4w
+    84 * Gregorian.SECONDS_PER_DAY,       // 12w
+    6 * 30 * Gregorian.SECONDS_PER_DAY,   // 6mo
+    9 * 30 * Gregorian.SECONDS_PER_DAY,   // 9mo
+    Gregorian.SECONDS_PER_YEAR            // 1y
   ] as Array<Lang.Number>;
 
   (:glance)
@@ -78,5 +57,53 @@ module Milestones {
     var remaining = milestone - elapsedTime.value();
 
     return 1 - (remaining.toFloat() / milestone.toFloat());
+  }
+
+  // Maps a target milestone to one of 6 NHS description bands.
+  // 0:24h  1:48h  2:72h  3:weeks(1-12w)  4:months(6-9mo)  5:1y+
+  function bandIndexFor(targetSeconds as Lang.Number) as Lang.Number {
+    if (targetSeconds <= Gregorian.SECONDS_PER_DAY)     { return 0; }
+    if (targetSeconds <= 2 * Gregorian.SECONDS_PER_DAY) { return 1; }
+    if (targetSeconds <= 3 * Gregorian.SECONDS_PER_DAY) { return 2; }
+    if (targetSeconds < 90 * Gregorian.SECONDS_PER_DAY) { return 3; }
+    if (targetSeconds < Gregorian.SECONDS_PER_YEAR)     { return 4; }
+    return 5;
+  }
+
+  // Picks the elapsed-display divisor: one tier finer than the target's label.
+  // Sub-week targets render elapsed in hours; everything else in days.
+  // So "23h / 48h" reads naturally; "260d / 1y" beats "0 / 1y".
+  function elapsedDivisorFor(targetSeconds as Lang.Number) as Lang.Number {
+    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY) {
+      return Gregorian.SECONDS_PER_HOUR;
+    }
+    return Gregorian.SECONDS_PER_DAY;
+  }
+
+  function elapsedUnitFor(targetSeconds as Lang.Number, units as Lang.Dictionary) as Lang.String {
+    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY) {
+      return units[:hour];
+    }
+    return units[:day];
+  }
+
+  // Formats a milestone duration in its natural unit. Bucket boundaries:
+  //   < 7 days  → hours    (24h, 48h)
+  //   < 90 days → weeks    (1w..12w)
+  //   < 1 year  → months   (6mo, 9mo)
+  //   ≥ 1 year  → years    (1y, 2y, …)
+  // `units` is a dict keyed by :hour :day :week :month :year (loaded from resources).
+  function labelFor(seconds as Lang.Number, units as Lang.Dictionary) as Lang.String {
+    if (seconds >= Gregorian.SECONDS_PER_YEAR) {
+      return (seconds / Gregorian.SECONDS_PER_YEAR).toString() + units[:year];
+    }
+    var monthSeconds = 30 * Gregorian.SECONDS_PER_DAY;
+    if (seconds >= 90 * Gregorian.SECONDS_PER_DAY) {
+      return (seconds / monthSeconds).toString() + units[:month];
+    }
+    if (seconds >= 7 * Gregorian.SECONDS_PER_DAY) {
+      return (seconds / (7 * Gregorian.SECONDS_PER_DAY)).toString() + units[:week];
+    }
+    return (seconds / Gregorian.SECONDS_PER_HOUR).toString() + units[:hour];
   }
 }

--- a/source/stats/Milestones.mc
+++ b/source/stats/Milestones.mc
@@ -8,6 +8,8 @@ import Stats;
 module Milestones {
   (:glance)
   const MILESTONES = [
+    20 * 60,                              // 20min
+    8 * Gregorian.SECONDS_PER_HOUR,       // 8h
     Gregorian.SECONDS_PER_DAY,            // 24h
     2 * Gregorian.SECONDS_PER_DAY,        // 48h
     3 * Gregorian.SECONDS_PER_DAY,        // 72h
@@ -59,40 +61,41 @@ module Milestones {
     return 1 - (remaining.toFloat() / milestone.toFloat());
   }
 
-  // Maps a target milestone to one of 6 NHS description bands.
-  // 0:24h  1:48h  2:72h  3:weeks(1-12w)  4:months(6-9mo)  5:1y+
+  // Maps a target milestone to one of 8 NHS description bands.
+  // 0:20min  1:8h  2:24h  3:48h  4:72h  5:weeks(1-12w)  6:months(6-9mo)  7:1y+
   function bandIndexFor(targetSeconds as Lang.Number) as Lang.Number {
-    if (targetSeconds <= Gregorian.SECONDS_PER_DAY)     { return 0; }
-    if (targetSeconds <= 2 * Gregorian.SECONDS_PER_DAY) { return 1; }
-    if (targetSeconds <= 3 * Gregorian.SECONDS_PER_DAY) { return 2; }
-    if (targetSeconds < 90 * Gregorian.SECONDS_PER_DAY) { return 3; }
-    if (targetSeconds < Gregorian.SECONDS_PER_YEAR)     { return 4; }
-    return 5;
+    if (targetSeconds <= 20 * 60)                          { return 0; }
+    if (targetSeconds <= 8 * Gregorian.SECONDS_PER_HOUR)   { return 1; }
+    if (targetSeconds <= Gregorian.SECONDS_PER_DAY)        { return 2; }
+    if (targetSeconds <= 2 * Gregorian.SECONDS_PER_DAY)    { return 3; }
+    if (targetSeconds <= 3 * Gregorian.SECONDS_PER_DAY)    { return 4; }
+    if (targetSeconds < 90 * Gregorian.SECONDS_PER_DAY)    { return 5; }
+    if (targetSeconds < Gregorian.SECONDS_PER_YEAR)        { return 6; }
+    return 7;
   }
 
   // Picks the elapsed-display divisor: one tier finer than the target's label.
-  // Sub-week targets render elapsed in hours; everything else in days.
-  // So "23h / 48h" reads naturally; "260d / 1y" beats "0 / 1y".
+  // Sub-hour targets render elapsed in minutes; sub-week in hours; else days.
+  // So "5min / 20min", "23h / 48h", and "260d / 1y" all read naturally.
   function elapsedDivisorFor(targetSeconds as Lang.Number) as Lang.Number {
-    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY) {
-      return Gregorian.SECONDS_PER_HOUR;
-    }
+    if (targetSeconds < Gregorian.SECONDS_PER_HOUR)     { return 60; }
+    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY)  { return Gregorian.SECONDS_PER_HOUR; }
     return Gregorian.SECONDS_PER_DAY;
   }
 
   function elapsedUnitFor(targetSeconds as Lang.Number, units as Lang.Dictionary) as Lang.String {
-    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY) {
-      return units[:hour];
-    }
+    if (targetSeconds < Gregorian.SECONDS_PER_HOUR)     { return units[:minute]; }
+    if (targetSeconds < 7 * Gregorian.SECONDS_PER_DAY)  { return units[:hour]; }
     return units[:day];
   }
 
   // Formats a milestone duration in its natural unit. Bucket boundaries:
-  //   < 7 days  → hours    (24h, 48h)
+  //   < 1 hour  → minutes  (20min)
+  //   < 7 days  → hours    (8h, 24h, 48h, 72h)
   //   < 90 days → weeks    (1w..12w)
   //   < 1 year  → months   (6mo, 9mo)
   //   ≥ 1 year  → years    (1y, 2y, …)
-  // `units` is a dict keyed by :hour :day :week :month :year (loaded from resources).
+  // `units` is a dict keyed by :minute :hour :day :week :month :year (loaded from resources).
   function labelFor(seconds as Lang.Number, units as Lang.Dictionary) as Lang.String {
     if (seconds >= Gregorian.SECONDS_PER_YEAR) {
       return (seconds / Gregorian.SECONDS_PER_YEAR).toString() + units[:year];
@@ -104,6 +107,9 @@ module Milestones {
     if (seconds >= 7 * Gregorian.SECONDS_PER_DAY) {
       return (seconds / (7 * Gregorian.SECONDS_PER_DAY)).toString() + units[:week];
     }
-    return (seconds / Gregorian.SECONDS_PER_HOUR).toString() + units[:hour];
+    if (seconds >= Gregorian.SECONDS_PER_HOUR) {
+      return (seconds / Gregorian.SECONDS_PER_HOUR).toString() + units[:hour];
+    }
+    return (seconds / 60).toString() + units[:minute];
   }
 }

--- a/source/stats/Milestones.tests.mc
+++ b/source/stats/Milestones.tests.mc
@@ -11,12 +11,29 @@ module MilestonesTests {
   var today = new Time.Moment(Time.now().value());
 
   const TEST_UNITS = {
+    :minute => "min",
     :hour => "h",
     :day => "d",
     :week => "w",
     :month => "mo",
     :year => "y",
   };
+
+  (:test)
+  function canGet20MinMilestone(logger as Logger) {
+    var duration = new Time.Duration(10 * 60);
+    var quitTime = today.subtract(duration) as Time.Moment;
+    var milestone = Milestones.closestMilestoneTo(quitTime, today);
+    return TestUtils.verifyValueEquals(logger, milestone, 20 * 60);
+  }
+
+  (:test)
+  function canGet8hMilestone(logger as Logger) {
+    var duration = new Time.Duration(5 * Gregorian.SECONDS_PER_HOUR);
+    var quitTime = today.subtract(duration) as Time.Moment;
+    var milestone = Milestones.closestMilestoneTo(quitTime, today);
+    return TestUtils.verifyValueEquals(logger, milestone, 8 * Gregorian.SECONDS_PER_HOUR);
+  }
 
   (:test)
   function canGet24hMilestone(logger as Logger) {
@@ -113,7 +130,7 @@ module MilestonesTests {
 
   (:test)
   function labelForCoversEveryMilestone(logger as Logger) {
-    var expected = ["24h", "48h", "72h", "1w", "2w", "4w", "12w", "6mo", "9mo", "1y"];
+    var expected = ["20min", "8h", "24h", "48h", "72h", "1w", "2w", "4w", "12w", "6mo", "9mo", "1y"];
     if (Milestones.NUMBER_OF_MILESTONES != expected.size()) {
       logger.debug("MILESTONES size " + Milestones.NUMBER_OF_MILESTONES + " != expected " + expected.size());
       return false;
@@ -149,7 +166,7 @@ module MilestonesTests {
   (:test)
   function bandIndexForMapsEachMilestone(logger as Logger) {
     // index in MILESTONES → expected band
-    var expected = [0, 1, 2, 3, 3, 3, 3, 4, 4, 5];
+    var expected = [0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 6, 7];
     if (Milestones.NUMBER_OF_MILESTONES != expected.size()) {
       logger.debug("MILESTONES size " + Milestones.NUMBER_OF_MILESTONES + " != expected " + expected.size());
       return false;
@@ -167,7 +184,31 @@ module MilestonesTests {
   (:test)
   function bandIndexForPastFinalMilestone(logger as Logger) {
     var band = Milestones.bandIndexFor(2 * Gregorian.SECONDS_PER_YEAR);
-    return TestUtils.verifyValueEquals(logger, band, 5);
+    return TestUtils.verifyValueEquals(logger, band, 7);
+  }
+
+  (:test)
+  function labelFor20Min(logger as Logger) {
+    var label = Milestones.labelFor(20 * 60, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "20min");
+  }
+
+  (:test)
+  function labelFor8h(logger as Logger) {
+    var label = Milestones.labelFor(8 * Gregorian.SECONDS_PER_HOUR, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "8h");
+  }
+
+  (:test)
+  function elapsedUnitForMinuteTargets(logger as Logger) {
+    var unit = Milestones.elapsedUnitFor(20 * 60, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, unit, "min");
+  }
+
+  (:test)
+  function elapsedDivisorForMinuteTargets(logger as Logger) {
+    var divisor = Milestones.elapsedDivisorFor(20 * 60);
+    return TestUtils.verifyValueEquals(logger, divisor, 60);
   }
 
   (:test)

--- a/source/stats/Milestones.tests.mc
+++ b/source/stats/Milestones.tests.mc
@@ -10,44 +10,52 @@ module MilestonesTests {
 
   var today = new Time.Moment(Time.now().value());
 
+  const TEST_UNITS = {
+    :hour => "h",
+    :day => "d",
+    :week => "w",
+    :month => "mo",
+    :year => "y",
+  };
+
   (:test)
-  function canGetOneDayMilestone(logger as Logger) {
+  function canGet24hMilestone(logger as Logger) {
     var duration = new Time.Duration((0.5 * Gregorian.SECONDS_PER_DAY) as Lang.Number);
     var quitTime = today.subtract(duration) as Time.Moment;
     var milestone = Milestones.closestMilestoneTo(quitTime, today);
-    return (milestone == Milestones.MILESTONES[0]);
+    return TestUtils.verifyValueEquals(logger, milestone, Gregorian.SECONDS_PER_DAY);
   }
 
   (:test)
-  function canGetTwoDayMilestone(logger as Logger) {
+  function canGet48hMilestone(logger as Logger) {
     var duration = new Time.Duration(Gregorian.SECONDS_PER_DAY + 1);
     var quitTime = today.subtract(duration) as Time.Moment;
     var milestone = Milestones.closestMilestoneTo(quitTime, today);
-    return (milestone == Milestones.MILESTONES[1]);
+    return TestUtils.verifyValueEquals(logger, milestone, 2 * Gregorian.SECONDS_PER_DAY);
   }
 
   (:test)
-  function canGetOneWeekMilestone(logger as Logger) {
+  function canGet1WeekMilestone(logger as Logger) {
     var duration = new Time.Duration(6 * Gregorian.SECONDS_PER_DAY + 1);
     var quitTime = today.subtract(duration) as Time.Moment;
     var milestone = Milestones.closestMilestoneTo(quitTime, today);
-    return (milestone == Milestones.MILESTONES[6]);
+    return TestUtils.verifyValueEquals(logger, milestone, 7 * Gregorian.SECONDS_PER_DAY);
   }
 
   (:test)
-  function canGetTwoWeekMilestone(logger as Logger) {
-    var duration = new Time.Duration(11 * Gregorian.SECONDS_PER_DAY);
+  function canGet12WeekMilestone(logger as Logger) {
+    var duration = new Time.Duration(60 * Gregorian.SECONDS_PER_DAY);
     var quitTime = today.subtract(duration) as Time.Moment;
     var milestone = Milestones.closestMilestoneTo(quitTime, today);
-    return (milestone == Milestones.MILESTONES[8]);
+    return TestUtils.verifyValueEquals(logger, milestone, 84 * Gregorian.SECONDS_PER_DAY);
   }
 
   (:test)
-  function canGetThreeMonthsMilestone(logger as Logger) {
-    var duration = new Time.Duration(2 * 30 * Gregorian.SECONDS_PER_DAY);
+  function canGet6MonthMilestone(logger as Logger) {
+    var duration = new Time.Duration(100 * Gregorian.SECONDS_PER_DAY);
     var quitTime = today.subtract(duration) as Time.Moment;
     var milestone = Milestones.closestMilestoneTo(quitTime, today);
-    return (milestone == Milestones.MILESTONES[11]);
+    return TestUtils.verifyValueEquals(logger, milestone, 6 * 30 * Gregorian.SECONDS_PER_DAY);
   }
 
   (:test)
@@ -61,10 +69,105 @@ module MilestonesTests {
 
   (:test)
   function progressPastLastMilestone(logger as Logger) {
-    var fiftyOneYears = new Time.Duration(51 * Gregorian.SECONDS_PER_YEAR);
-    var quitTime = today.subtract(fiftyOneYears) as Time.Moment;
+    var twoYears = new Time.Duration(2 * Gregorian.SECONDS_PER_YEAR);
+    var quitTime = today.subtract(twoYears) as Time.Moment;
     var progress = Milestones.milestoneProgress(quitTime, today);
     return TestUtils.verifyValueEquals(logger, progress, 1.0);
+  }
+
+  (:test)
+  function labelFor24h(logger as Logger) {
+    var label = Milestones.labelFor(Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "24h");
+  }
+
+  (:test)
+  function labelFor48h(logger as Logger) {
+    var label = Milestones.labelFor(2 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "48h");
+  }
+
+  (:test)
+  function labelFor1Week(logger as Logger) {
+    var label = Milestones.labelFor(7 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "1w");
+  }
+
+  (:test)
+  function labelFor12Weeks(logger as Logger) {
+    var label = Milestones.labelFor(84 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "12w");
+  }
+
+  (:test)
+  function labelFor6Months(logger as Logger) {
+    var label = Milestones.labelFor(6 * 30 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "6mo");
+  }
+
+  (:test)
+  function labelFor1Year(logger as Logger) {
+    var label = Milestones.labelFor(Gregorian.SECONDS_PER_YEAR, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, label, "1y");
+  }
+
+  (:test)
+  function labelForCoversEveryMilestone(logger as Logger) {
+    var expected = ["24h", "48h", "72h", "1w", "2w", "4w", "12w", "6mo", "9mo", "1y"];
+    if (Milestones.NUMBER_OF_MILESTONES != expected.size()) {
+      logger.debug("MILESTONES size " + Milestones.NUMBER_OF_MILESTONES + " != expected " + expected.size());
+      return false;
+    }
+    for (var i = 0; i < Milestones.NUMBER_OF_MILESTONES; i++) {
+      var label = Milestones.labelFor(Milestones.MILESTONES[i], TEST_UNITS);
+      if (!label.equals(expected[i])) {
+        logger.debug("MILESTONES[" + i + "] labeled " + label + ", expected " + expected[i]);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  (:test)
+  function elapsedUnitForHourTargets(logger as Logger) {
+    var unit = Milestones.elapsedUnitFor(2 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, unit, "h");
+  }
+
+  (:test)
+  function elapsedUnitForWeekTargets(logger as Logger) {
+    var unit = Milestones.elapsedUnitFor(7 * Gregorian.SECONDS_PER_DAY, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, unit, "d");
+  }
+
+  (:test)
+  function elapsedUnitForYearTargets(logger as Logger) {
+    var unit = Milestones.elapsedUnitFor(Gregorian.SECONDS_PER_YEAR, TEST_UNITS);
+    return TestUtils.verifyValueEquals(logger, unit, "d");
+  }
+
+  (:test)
+  function bandIndexForMapsEachMilestone(logger as Logger) {
+    // index in MILESTONES → expected band
+    var expected = [0, 1, 2, 3, 3, 3, 3, 4, 4, 5];
+    if (Milestones.NUMBER_OF_MILESTONES != expected.size()) {
+      logger.debug("MILESTONES size " + Milestones.NUMBER_OF_MILESTONES + " != expected " + expected.size());
+      return false;
+    }
+    for (var i = 0; i < Milestones.NUMBER_OF_MILESTONES; i++) {
+      var band = Milestones.bandIndexFor(Milestones.MILESTONES[i]);
+      if (band != expected[i]) {
+        logger.debug("MILESTONES[" + i + "] band=" + band + ", expected " + expected[i]);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  (:test)
+  function bandIndexForPastFinalMilestone(logger as Logger) {
+    var band = Milestones.bandIndexFor(2 * Gregorian.SECONDS_PER_YEAR);
+    return TestUtils.verifyValueEquals(logger, band, 5);
   }
 
   (:test)

--- a/source/view/MilestonesView.mc
+++ b/source/view/MilestonesView.mc
@@ -1,0 +1,162 @@
+import Toybox.Application;
+import Toybox.WatchUi;
+import Toybox.Graphics;
+import Toybox.Lang;
+import Toybox.Math;
+import Toybox.System;
+import Toybox.Time;
+
+import Milestones;
+import Settings;
+import Stats;
+
+class MilestonesView extends StatView {
+  private var _units as Lang.Dictionary?;
+  private var _arc as CircularProgressBar?;
+  private var _descriptions as Array<String>?;
+  private var _motivationals as Array< Array<String> >?;
+  private var _currentMessage as String?;
+  private var _descArea as WatchUi.TextArea?;
+
+  private const STORAGE_KEY_BANDS_SEEN = "milestonesBandsSeen";
+
+  // Entry animation: arc sweeps 0 → real progress on view show.
+  // Driven by System.getTimer() inside onUpdate (no Timer.Timer — instance
+  // method indirect lookup crashes the TVM, see learning_monkeyc_indirect_method_lookup).
+  private const ANIM_DURATION_MS = 700;
+  private var _animStartMs as Number = 0;
+
+  function initialize() {
+    StatView.initialize();
+  }
+
+  function onLayout(dc as Dc) as Void {
+    StatView.onLayout(dc);
+
+    _units = {
+      :hour => Application.loadResource(Rez.Strings.Milestones_UnitHour) as String,
+      :day => Application.loadResource(Rez.Strings.Milestones_UnitDay) as String,
+      :week => Application.loadResource(Rez.Strings.Milestones_UnitWeek) as String,
+      :month => Application.loadResource(Rez.Strings.Milestones_UnitMonth) as String,
+      :year => Application.loadResource(Rez.Strings.Milestones_UnitYear) as String,
+    };
+
+    _arc = new CircularProgressBar({
+      :colorBase => Graphics.COLOR_DK_GRAY,
+      :colorActive => Graphics.COLOR_BLUE,
+    });
+
+    _descriptions = [
+      Application.loadResource(Rez.Strings.Milestones_Desc_24h) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_48h) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_72h) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_Weeks) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_Months) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_1y) as String,
+    ];
+
+    _motivationals = [
+      [Application.loadResource(Rez.Strings.Milestones_Mot_24h_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_24h_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_48h_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_48h_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_72h_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_72h_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_Weeks_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_Weeks_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_Months_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_Months_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_1y_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_1y_2) as String],
+    ];
+
+    var width = dc.getWidth();
+    var height = dc.getHeight();
+    _descArea = new WatchUi.TextArea({
+      :text => "",
+      :color => Graphics.COLOR_LT_GRAY,
+      :font => [Graphics.FONT_TINY, Graphics.FONT_XTINY],
+      :locX => (width * 0.15).toNumber(),
+      :locY => (height * 0.55).toNumber(),
+      :width => (width * 0.7).toNumber(),
+      :height => (height * 0.35).toNumber(),
+      :justification => Graphics.TEXT_JUSTIFY_CENTER | Graphics.TEXT_JUSTIFY_VCENTER,
+    });
+  }
+
+  function onShow() as Void {
+    StatView.onShow();
+    _animStartMs = System.getTimer();
+
+    var now = new Time.Moment(Time.now().value());
+    var nextSeconds = Milestones.closestMilestoneTo(Settings.getQuitDate(), now);
+    _currentMessage = pickMessageFor(Milestones.bandIndexFor(nextSeconds));
+  }
+
+  // First visit to a band: show the NHS fact and mark the band seen.
+  // Subsequent visits: random pick across {NHS, motivationals[band]...}.
+  // Persistence is a 6-bit bitfield in Application.Storage so we keep one key
+  // instead of six; unset reads as 0 so v0.5.0 upgraders behave like fresh installs.
+  private function pickMessageFor(band as Number) as String {
+    var raw = Application.Storage.getValue(STORAGE_KEY_BANDS_SEEN);
+    var seen = (raw instanceof Lang.Number) ? raw : 0;
+    var mask = 1 << band;
+
+    if ((seen & mask) == 0) {
+      Application.Storage.setValue(STORAGE_KEY_BANDS_SEEN, seen | mask);
+      return _descriptions[band];
+    }
+
+    var motivationals = _motivationals[band];
+    var poolSize = 1 + motivationals.size();
+    var pick = Math.rand() % poolSize;
+    if (pick == 0) { return _descriptions[band]; }
+    return motivationals[pick - 1];
+  }
+
+  function onUpdate(dc as Dc) as Void {
+    var now = new Time.Moment(Time.now().value());
+    var quitDate = Settings.getQuitDate();
+
+    var nextSeconds = Milestones.closestMilestoneTo(quitDate, now);
+    var progress = Milestones.milestoneProgress(quitDate, now);
+
+    // "elapsed<finerUnit> / target<targetUnit>" — e.g. "23h / 48h", "5d / 1w", "260d / 1y".
+    var elapsedSeconds = Stats.durationSince(quitDate, now).value();
+    var elapsedDivisor = Milestones.elapsedDivisorFor(nextSeconds);
+    var elapsedCount = elapsedSeconds / elapsedDivisor;
+    var elapsedUnit = Milestones.elapsedUnitFor(nextSeconds, _units);
+    var targetLabel = Milestones.labelFor(nextSeconds, _units);
+    title = elapsedCount.toString() + elapsedUnit + " / " + targetLabel;
+
+    _descArea.setText(_currentMessage);
+
+    StatView.onUpdate(dc);
+    _descArea.draw(dc);
+
+    var t = (System.getTimer() - _animStartMs).toFloat() / ANIM_DURATION_MS.toFloat();
+    var animating = t < 1.0;
+    if (t > 1.0) { t = 1.0; }
+    if (t < 0.0) { t = 0.0; } // System.getTimer() rollover guard
+    // Ease-out quadratic: 1 - (1-t)^2
+    var eased = 1.0 - (1.0 - t) * (1.0 - t);
+    _arc.setValue(progress * eased);
+    _arc.draw(dc);
+
+    if (animating) {
+      WatchUi.requestUpdate();
+    }
+  }
+
+  // FONT_NUMBER_* variants are digits-only — the unit suffix ("d" / "mo" / "y")
+  // would render as a tofu box. FONT_LARGE has the full glyph set.
+  // Title sits in the upper third; description TextArea owns the lower half.
+  function drawTitle(dc as Dc) as Void {
+    var height = dc.getHeight();
+    dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_TRANSPARENT);
+    dc.drawText(titleX, (height * 0.32).toNumber(), Graphics.FONT_LARGE, title, Graphics.TEXT_JUSTIFY_CENTER);
+  }
+
+  // Subtitle is now replaced by the description TextArea — no-op.
+  function drawSubTitle(dc as Dc) as Void {}
+}

--- a/source/view/MilestonesView.mc
+++ b/source/view/MilestonesView.mc
@@ -34,6 +34,7 @@ class MilestonesView extends StatView {
     StatView.onLayout(dc);
 
     _units = {
+      :minute => Application.loadResource(Rez.Strings.Milestones_UnitMinute) as String,
       :hour => Application.loadResource(Rez.Strings.Milestones_UnitHour) as String,
       :day => Application.loadResource(Rez.Strings.Milestones_UnitDay) as String,
       :week => Application.loadResource(Rez.Strings.Milestones_UnitWeek) as String,
@@ -47,6 +48,8 @@ class MilestonesView extends StatView {
     });
 
     _descriptions = [
+      Application.loadResource(Rez.Strings.Milestones_Desc_20min) as String,
+      Application.loadResource(Rez.Strings.Milestones_Desc_8h) as String,
       Application.loadResource(Rez.Strings.Milestones_Desc_24h) as String,
       Application.loadResource(Rez.Strings.Milestones_Desc_48h) as String,
       Application.loadResource(Rez.Strings.Milestones_Desc_72h) as String,
@@ -56,6 +59,10 @@ class MilestonesView extends StatView {
     ];
 
     _motivationals = [
+      [Application.loadResource(Rez.Strings.Milestones_Mot_20min_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_20min_2) as String],
+      [Application.loadResource(Rez.Strings.Milestones_Mot_8h_1) as String,
+       Application.loadResource(Rez.Strings.Milestones_Mot_8h_2) as String],
       [Application.loadResource(Rez.Strings.Milestones_Mot_24h_1) as String,
        Application.loadResource(Rez.Strings.Milestones_Mot_24h_2) as String],
       [Application.loadResource(Rez.Strings.Milestones_Mot_48h_1) as String,

--- a/source/view/NavigationBehavior.mc
+++ b/source/view/NavigationBehavior.mc
@@ -4,7 +4,7 @@ import Toybox.Lang;
 
 class NavigationBehavior extends BehaviorDelegate {
   private var _currentPage as Number;
-  private const _numberOfViews as Number = 3;
+  private const _numberOfViews as Number = 4;
 
   function initialize(currentPage as Number) {
     _currentPage = currentPage;
@@ -32,10 +32,11 @@ class NavigationBehavior extends BehaviorDelegate {
   // To add a view: add a case here and increment _numberOfViews.
   function getView(page as Number) as WatchUi.View {
     switch (page) {
-      case 0: return new CigarettesNotSmokedView();
-      case 1: return new MoneyNotSpentView();
-      case 2: return new CleanSinceView();
-      default: return new CigarettesNotSmokedView();
+      case 0: return new MilestonesView();
+      case 1: return new CigarettesNotSmokedView();
+      case 2: return new MoneyNotSpentView();
+      case 3: return new CleanSinceView();
+      default: return new MilestonesView();
     }
   }
 }


### PR DESCRIPTION
## Summary
- New **MilestonesView** as the widget's landing page: circular arc + `elapsed / target` fraction (e.g. `29h / 48h`) + a description that motivates returns
- Curated milestone set (`24h, 48h, 72h, 1w, 2w, 4w, 12w, 6mo, 9mo, 1y`) with hour/week-aware labels via `Milestones.labelFor`
- 6 NHS-paraphrased descriptions + 12 motivational variants (2 per band); first visit per band shows the NHS fact, repeats randomize across `{NHS, mot1, mot2}`. Persisted as a 6-bit bitfield in `Application.Storage["milestonesBandsSeen"]`
- Hungarian copy included; both NHS and motivational strings flagged for native review
- Ease-out arc sweep on view show, driven by `System.getTimer()` inside `onUpdate` (no `Timer.Timer` — instance `method(:name)` indirect lookup crashes the simulator TVM)

## Test plan
- [x] `make test` — 63/63 passing (incl. new `labelFor`, `bandIndexFor`, `elapsedUnitFor` coverage)
- [x] `make build` — clean on fenix6 (only the pre-existing `GlanceView` container-access warning)
- [ ] Simulator visual on fenix6 and fenix7:
  - Fresh install: lands on MilestonesView with NHS 24h copy and near-empty arc
  - Set quit date back via Settings → fraction + description switch bands correctly
  - Re-open the widget multiple times in the same band → motivational variants surface
  - Hungarian locale: copy wraps cleanly inside the `TextArea` bounds
- [ ] v0.5.0 upgrade smoke test: existing user's stored `lastPage` (0/1/2) reshuffles by one slot but doesn't crash; properties round-trip via `SettingsTests.upgradeFromV040_preservesAllUserSettings`